### PR TITLE
💄  style: reset css 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 import AppRouter from "./routes/Router";
+import { Global } from "@emotion/react";
+import reset from "./style/reset";
 
 const App: React.FC = () => {
-  return <AppRouter />;
+  return (
+    <div>
+      <Global styles={reset} />
+      <AppRouter />
+    </div>
+  );
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import AppRouter from "./routes/Router";
 import { Global } from "@emotion/react";
-import reset from "./style/reset";
+import reset from "./styles/reset";
 
 const App: React.FC = () => {
   return (

--- a/src/style/reset.tsx
+++ b/src/style/reset.tsx
@@ -1,0 +1,188 @@
+import { css } from "@emotion/react";
+
+const reset = css`
+  @font-face {
+    font-family: "Roboto";
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2)
+      format("woff2");
+  }
+  @font-face {
+    font-family: "Noto Sans KR";
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/notosanskr/v27/PbykFmXiEBPT4ITbgNA5Cgm203Tq4JJWq209pU0DPdWuqxJFA4GNDCBYtw.1.woff2)
+      format("woff2");
+  }
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+    font-family: "NanumBarunGothic", sans-serif;
+  }
+
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+
+  body {
+    line-height: 1;
+  }
+
+  ol,
+  ul {
+    list-style: none;
+  }
+
+  blockquote,
+  q {
+    quotes: none;
+  }
+
+  blockquote {
+    &:before,
+    &:after {
+      content: "";
+      content: none;
+    }
+  }
+
+  q {
+    &:before,
+    &:after {
+      content: "";
+      content: none;
+    }
+  }
+
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  // customized
+  body {
+    background-color: rgba(249, 251, 253);
+  }
+
+  #root {
+    height: 100vh;
+    box-sizing: border-box;
+  }
+
+  a {
+    text-decoration: none;
+
+    &,
+    &:visited {
+      color: inherit;
+    }
+  }
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  svg,
+  path {
+    pointer-events: none;
+  }
+`;
+
+export default reset;

--- a/src/styles/reset.tsx
+++ b/src/styles/reset.tsx
@@ -1,22 +1,7 @@
 import { css } from "@emotion/react";
 
 const reset = css`
-  @font-face {
-    font-family: "Roboto";
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-    src: url(https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2)
-      format("woff2");
-  }
-  @font-face {
-    font-family: "Noto Sans KR";
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-    src: url(https://fonts.gstatic.com/s/notosanskr/v27/PbykFmXiEBPT4ITbgNA5Cgm203Tq4JJWq209pU0DPdWuqxJFA4GNDCBYtw.1.woff2)
-      format("woff2");
-  }
+  @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap");
   html,
   body,
   div,
@@ -102,9 +87,7 @@ const reset = css`
     padding: 0;
     border: 0;
     font-size: 100%;
-    font: inherit;
     vertical-align: baseline;
-    font-family: "NanumBarunGothic", sans-serif;
   }
 
   article,
@@ -123,6 +106,7 @@ const reset = css`
 
   body {
     line-height: 1;
+    font-family: "Noto Sans KR", sans-serif;
   }
 
   ol,

--- a/src/styles/reset.tsx
+++ b/src/styles/reset.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 
 const reset = css`
   @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap");
+  @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");
   html,
   body,
   div,
@@ -87,7 +88,9 @@ const reset = css`
     padding: 0;
     border: 0;
     font-size: 100%;
+    font: inherit;
     vertical-align: baseline;
+    font-family: "Noto Sans KR", sans-serif;
   }
 
   article,
@@ -106,7 +109,6 @@ const reset = css`
 
   body {
     line-height: 1;
-    font-family: "Noto Sans KR", sans-serif;
   }
 
   ol,


### PR DESCRIPTION
# 개요
* reset css 설정
* noto-sans kr을 전체 적용 폰트로 지정 (Roboto 폰트는 추가만)
# 작업 내용
![image](https://user-images.githubusercontent.com/95457808/173127148-6d89b88a-9c63-405a-97d7-28b4dc876758.png)
```
<h1>안녕</h1>
<p>안녕</p>
<h1>Hello</h1>
<p>Hello</p>
```
# 관련 이슈
Close #68 
# 사진

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
