### PR TITLE
✨ feat: AppLayout 컴포넌트 추가

### DIFF
--- a/src/components/common/AppLayout/AppLayout.stories.tsx
+++ b/src/components/common/AppLayout/AppLayout.stories.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import AppLayout from "./AppLayout";
+
+export default {
+  title: "Component/AppLayout",
+  component: AppLayout
+} as ComponentMeta<typeof AppLayout>;
+
+const Children = styled.div`
+  width: 100%;
+  height: 500px;
+  background-color: pink;
+`;
+
+export const Default: ComponentStory<typeof AppLayout> = () => {
+  return (
+    <AppLayout>
+      <Children>Children</Children>
+    </AppLayout>
+  );
+};

--- a/src/components/common/AppLayout/AppLayout.tsx
+++ b/src/components/common/AppLayout/AppLayout.tsx
@@ -6,7 +6,13 @@ interface AppLayoutInterface {
 
 const AppLayout: React.FC<AppLayoutInterface> = ({ children }) => {
   // header, footer 컴포넌트 추가
-  return <S.Layout>{children}</S.Layout>;
+  return (
+    <>
+      <S.Header />
+      <S.Layout>{children}</S.Layout>
+      <S.Footer />
+    </>
+  );
 };
 
 export default AppLayout;

--- a/src/components/common/AppLayout/AppLayout.tsx
+++ b/src/components/common/AppLayout/AppLayout.tsx
@@ -1,0 +1,12 @@
+import * as S from "./style";
+
+interface AppLayoutInterface {
+  children: React.ReactNode;
+}
+
+const AppLayout: React.FC<AppLayoutInterface> = ({ children }) => {
+  // header, footer 컴포넌트 추가
+  return <S.Layout>{children}</S.Layout>;
+};
+
+export default AppLayout;

--- a/src/components/common/AppLayout/index.tsx
+++ b/src/components/common/AppLayout/index.tsx
@@ -1,0 +1,2 @@
+import AppLayout from "./AppLayout";
+export default AppLayout;

--- a/src/components/common/AppLayout/style.tsx
+++ b/src/components/common/AppLayout/style.tsx
@@ -9,3 +9,12 @@ export const Layout = styled.div`
     box-sizing: border-box;
   }
 `;
+
+export const Header = styled.div`
+  height: 60px;
+  background-color: #f5f5f5;
+`;
+export const Footer = styled.div`
+  height: 196px;
+  background-color: #f5f5f5;
+`;

--- a/src/components/common/AppLayout/style.tsx
+++ b/src/components/common/AppLayout/style.tsx
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+export const Layout = styled.div`
+  max-width: 700px;
+  min-width: 340px;
+  margin: auto;
+  @media (max-width: 700px) {
+    padding: 0 18px;
+    box-sizing: border-box;
+  }
+`;


### PR DESCRIPTION
# 개요
`AppLayout` 컴포넌트 추가

# 작업 내용
- children으로 내부 컨텐츠 받습니다.  
- max-width가 700px 이고 이후 이보다 작으면 좌우 18px의 패딩이 생기며 좌우 간격을 유지시켜줌니다.
- Header와 Footer는 임시로 자리만 잡아놨습니다. 이후 컴포넌트로 추가 예정

# 관련 이슈
`AppLayout` 컴포넌트

# 사진
![image](https://user-images.githubusercontent.com/87519250/173177027-273443a5-567d-49af-93c0-8d4043017b93.png)


<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
