### PR TITLE
✨ feat: API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react-dom": "^18.0.5",
         "@types/react-router-dom": "^5.3.3",
         "antd": "^4.21.0",
+        "axios": "^0.27.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-router": "^6.3.0",
@@ -12743,6 +12744,28 @@
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -41841,6 +41864,27 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
       "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/react-dom": "^18.0.5",
     "@types/react-router-dom": "^5.3.3",
     "antd": "^4.21.0",
+    "axios": "^0.27.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-router": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -94,5 +94,6 @@
     "prettier": "^2.6.2",
     "prop-types": "^15.8.1",
     "webpack": "^5.73.0"
-  }
+  },
+  "proxy": "http://kdt.frontend.2nd.programmers.co.kr:5005"
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,5 @@
     "prettier": "^2.6.2",
     "prop-types": "^15.8.1",
     "webpack": "^5.73.0"
-  },
-  "proxy": "http://kdt.frontend.2nd.programmers.co.kr:5005"
+  }
 }

--- a/src/types/apis.ts
+++ b/src/types/apis.ts
@@ -1,0 +1,32 @@
+export interface ISignIn {
+  email: string;
+  password: string;
+}
+
+export interface ISignUp {
+  email: string;
+  fullName: string;
+  password: string;
+}
+
+export interface IChangInfo {
+  fullName: string;
+  userName: string;
+}
+
+export interface IUserPostList {
+  offset: number;
+  limit: number;
+}
+
+export interface ICreateComment {
+  comment: string;
+  postId: string;
+}
+
+export interface ICreateNotification {
+  notificationType: string;
+  notificationTypeId: string;
+  userId: string;
+  postId?: string;
+}

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,0 +1,100 @@
+export interface IUser {
+  coverImage?: string; // 커버 이미지
+  image?: string; // 프로필 이미지
+  role: string;
+  emailVerified: boolean; // 사용되지 않음
+  banned: boolean; // 사용되지 않음
+  isOnline: boolean;
+  posts: IPost[];
+  likes: ILike[];
+  comments: string[];
+  followers: IFollow[];
+  following: IFollow[];
+  notifications: INotification[];
+  messages: IMessage[];
+  _id: string;
+  fullName: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IChannel {
+  authRequired: boolean; // 사용되지 않음
+  posts: string[];
+  _id: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IPost {
+  likes: ILike[];
+  comments: IComment[];
+  _id: string;
+  image?: string;
+  imagePublicId?: string;
+  title: string;
+  channel: IChannel;
+  author: IUser;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ILike {
+  _id: string;
+  user: string; // 사용자 id;
+  post: string; // 포스트 id;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IComment {
+  _id: string;
+  comment: string;
+  author: IUser;
+  post: string; // 포스트 id;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface INotification {
+  seen: boolean;
+  _id: string;
+  author: IUser;
+  user: IUser | string;
+  post?: string; // 포스트 id
+  follow?: string; // 사용자 id
+  comment?: IComment;
+  message?: string; // 메시지 id
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IFollow {
+  _id: string;
+  user: string; // 사용자 id
+  follower: string; // 사용자 id
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IConversation {
+  _id: string[];
+  message: string;
+  sender: IUser;
+  receiver: IUser;
+  seen: boolean;
+  createdAt: string;
+}
+
+export interface IMessage {
+  _id: string;
+  message: string;
+  sender: IUser;
+  receiver: IUser;
+  seen: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/utils/apis/auth.ts
+++ b/src/utils/apis/auth.ts
@@ -1,6 +1,5 @@
 import { unauthRequest, authRequest } from "./common";
 import { ISignIn, ISignUp } from "../../types/apis";
-import storage from "../storage";
 
 const authAPI = {
   signIn: (payload: ISignIn) => unauthRequest.post("/login", payload),

--- a/src/utils/apis/auth.ts
+++ b/src/utils/apis/auth.ts
@@ -1,0 +1,32 @@
+import { unauthRequest, authRequest } from "./common";
+import { ISignIn, ISignUp } from "../../types/apis";
+import storage from "../storage";
+
+const authAPI = {
+  signIn: (payload: ISignIn) => {
+    let token = null;
+    const result = unauthRequest
+      .post("/login", payload)
+      .then((res) => {
+        if (res.status === 200) {
+          token = res.data.token;
+        }
+        return res;
+      })
+      .catch((error) => error);
+
+    storage.setItem("TOKEN", token);
+    return result;
+  },
+  signUp: (payload: ISignUp) => {
+    return unauthRequest.post("/signup", payload);
+  },
+  logOut: () => {
+    return authRequest.post("/logout");
+  },
+  checkAuthUser: () => {
+    return authRequest.get("/auth-user");
+  }
+};
+
+export default authAPI;

--- a/src/utils/apis/auth.ts
+++ b/src/utils/apis/auth.ts
@@ -3,30 +3,10 @@ import { ISignIn, ISignUp } from "../../types/apis";
 import storage from "../storage";
 
 const authAPI = {
-  signIn: (payload: ISignIn) => {
-    let token = null;
-    const result = unauthRequest
-      .post("/login", payload)
-      .then((res) => {
-        if (res.status === 200) {
-          token = res.data.token;
-        }
-        return res;
-      })
-      .catch((error) => error);
-
-    storage.setItem("TOKEN", token);
-    return result;
-  },
-  signUp: (payload: ISignUp) => {
-    return unauthRequest.post("/signup", payload);
-  },
-  logOut: () => {
-    return authRequest.post("/logout");
-  },
-  checkAuthUser: () => {
-    return authRequest.get("/auth-user");
-  }
+  signIn: (payload: ISignIn) => unauthRequest.post("/login", payload),
+  signUp: (payload: ISignUp) => unauthRequest.post("/signup", payload),
+  logOut: () => authRequest.post("/logout"),
+  checkAuthUser: () => authRequest.get("/auth-user")
 };
 
 export default authAPI;

--- a/src/utils/apis/channel.ts
+++ b/src/utils/apis/channel.ts
@@ -1,0 +1,12 @@
+import { unauthRequest } from "./common";
+
+const channelAPI = {
+  getChannelList: async () => {
+    return unauthRequest.get("/channels");
+  },
+  getChannelInfo: async (name: string) => {
+    return unauthRequest.get(`/channels/${name}`);
+  }
+};
+
+export default channelAPI;

--- a/src/utils/apis/channel.ts
+++ b/src/utils/apis/channel.ts
@@ -1,12 +1,8 @@
 import { unauthRequest } from "./common";
 
 const channelAPI = {
-  getChannelList: async () => {
-    return unauthRequest.get("/channels");
-  },
-  getChannelInfo: async (name: string) => {
-    return unauthRequest.get(`/channels/${name}`);
-  }
+  getChannelList: () => unauthRequest.get("/channels"),
+  getChannelInfo: (name: string) => unauthRequest.get(`/channels/${name}`)
 };
 
 export default channelAPI;

--- a/src/utils/apis/comment.ts
+++ b/src/utils/apis/comment.ts
@@ -1,0 +1,13 @@
+import { authRequest } from "./common";
+import { ICreateComment } from "../../types/apis";
+
+const commentAPI = {
+  createComment: async (payload: ICreateComment) => {
+    return authRequest.post("/comments/create", payload);
+  },
+  deleteComment: async (commentId: string) => {
+    return authRequest.delete("/comments/delete", { data: { id: commentId } });
+  }
+};
+
+export default commentAPI;

--- a/src/utils/apis/comment.ts
+++ b/src/utils/apis/comment.ts
@@ -2,12 +2,10 @@ import { authRequest } from "./common";
 import { ICreateComment } from "../../types/apis";
 
 const commentAPI = {
-  createComment: async (payload: ICreateComment) => {
-    return authRequest.post("/comments/create", payload);
-  },
-  deleteComment: async (commentId: string) => {
-    return authRequest.delete("/comments/delete", { data: { id: commentId } });
-  }
+  createComment: (payload: ICreateComment) =>
+    authRequest.post("/comments/create", payload),
+  deleteComment: (commentId: string) =>
+    authRequest.delete("/comments/delete", { data: { id: commentId } })
 };
 
 export default commentAPI;

--- a/src/utils/apis/common.ts
+++ b/src/utils/apis/common.ts
@@ -1,15 +1,15 @@
 import axios from "axios";
 import storage from "../storage";
 
-// CORS 풀리면 baseURL로 변경
 const baseURL = "http://kdt.frontend.2nd.programmers.co.kr:5005";
 
-const unauthRequest = axios.create({});
-unauthRequest.interceptors.response.use(
-  (config) => config,
-  (error) => Promise.reject(error.response)
-);
-const authRequest = axios.create({});
+const unauthRequest = axios.create({
+  baseURL
+});
+
+const authRequest = axios.create({
+  baseURL
+});
 authRequest.interceptors.request.use((config) => {
   config.headers.authorization = "Bearer " + storage.getItem("TOKEN", "");
   return config;

--- a/src/utils/apis/common.ts
+++ b/src/utils/apis/common.ts
@@ -1,7 +1,9 @@
 import axios from "axios";
 import storage from "../storage";
 
-const baseURL = "http://kdt.frontend.2nd.programmers.co.kr:5005";
+const { REACT_APP_END_POINT, REACT_APP_PORT } = process.env;
+
+const baseURL = `${REACT_APP_END_POINT}:${REACT_APP_PORT}`;
 
 const unauthRequest = axios.create({
   baseURL

--- a/src/utils/apis/common.ts
+++ b/src/utils/apis/common.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+import storage from "../storage";
+
+// CORS 풀리면 baseURL로 변경
+const baseURL = "http://kdt.frontend.2nd.programmers.co.kr:5005";
+
+const unauthRequest = axios.create({});
+unauthRequest.interceptors.response.use(
+  (config) => {
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error.response);
+  }
+);
+const authRequest = axios.create({});
+authRequest.interceptors.request.use((config) => {
+  config.headers.authorization = "Bearer " + storage.getItem("TOKEN", "");
+  return config;
+});
+
+export { unauthRequest, authRequest };

--- a/src/utils/apis/common.ts
+++ b/src/utils/apis/common.ts
@@ -6,12 +6,8 @@ const baseURL = "http://kdt.frontend.2nd.programmers.co.kr:5005";
 
 const unauthRequest = axios.create({});
 unauthRequest.interceptors.response.use(
-  (config) => {
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error.response);
-  }
+  (config) => config,
+  (error) => Promise.reject(error.response)
 );
 const authRequest = axios.create({});
 authRequest.interceptors.request.use((config) => {

--- a/src/utils/apis/follow.ts
+++ b/src/utils/apis/follow.ts
@@ -1,0 +1,12 @@
+import { authRequest } from "./common";
+
+const followAPI = {
+  createFollow: async (userId: string) => {
+    return authRequest.post("/follow/create", { userId });
+  },
+  deleteFollow: async (userId: string) => {
+    return authRequest.delete("/follow/delete", { data: { id: userId } });
+  }
+};
+
+export default followAPI;

--- a/src/utils/apis/follow.ts
+++ b/src/utils/apis/follow.ts
@@ -1,12 +1,10 @@
 import { authRequest } from "./common";
 
 const followAPI = {
-  createFollow: async (userId: string) => {
-    return authRequest.post("/follow/create", { userId });
-  },
-  deleteFollow: async (userId: string) => {
-    return authRequest.delete("/follow/delete", { data: { id: userId } });
-  }
+  createFollow: (userId: string) =>
+    authRequest.post("/follow/create", { userId }),
+  deleteFollow: (userId: string) =>
+    authRequest.delete("/follow/delete", { data: { id: userId } })
 };
 
 export default followAPI;

--- a/src/utils/apis/index.ts
+++ b/src/utils/apis/index.ts
@@ -1,0 +1,23 @@
+import authAPI from "./auth";
+import channelAPI from "./channel";
+import commentAPI from "./comment";
+import followAPI from "./follow";
+import likeAPI from "./like";
+import notificationAPI from "./notification";
+import postAPI from "./post";
+import searchAPI from "./search";
+import settingAPI from "./setting";
+import userAPI from "./user";
+
+export {
+  authAPI,
+  channelAPI,
+  commentAPI,
+  followAPI,
+  likeAPI,
+  notificationAPI,
+  postAPI,
+  searchAPI,
+  settingAPI,
+  userAPI
+};

--- a/src/utils/apis/like.ts
+++ b/src/utils/apis/like.ts
@@ -1,12 +1,9 @@
 import { authRequest } from "./common";
 
 const likeAPI = {
-  createLike: async (postId: string) => {
-    return authRequest.post("/likes/create", { postId });
-  },
-  deleteLike: async (postId: string) => {
-    return authRequest.delete("/likes/delete", { data: { id: postId } });
-  }
+  createLike: (postId: string) => authRequest.post("/likes/create", { postId }),
+  deleteLike: (postId: string) =>
+    authRequest.delete("/likes/delete", { data: { id: postId } })
 };
 
 export default likeAPI;

--- a/src/utils/apis/like.ts
+++ b/src/utils/apis/like.ts
@@ -1,0 +1,12 @@
+import { authRequest } from "./common";
+
+const likeAPI = {
+  createLike: async (postId: string) => {
+    return authRequest.post("/likes/create", { postId });
+  },
+  deleteLike: async (postId: string) => {
+    return authRequest.delete("/likes/delete", { data: { id: postId } });
+  }
+};
+
+export default likeAPI;

--- a/src/utils/apis/notification.ts
+++ b/src/utils/apis/notification.ts
@@ -1,0 +1,16 @@
+import { authRequest } from "./common";
+import { ICreateNotification } from "../../types/apis";
+
+const notificationAPI = {
+  getNotificationList: async () => {
+    return authRequest.get("/notifications");
+  },
+  seenNotification: async () => {
+    return authRequest.get("/notifications/seen");
+  },
+  createNotification: async (payload: ICreateNotification) => {
+    return authRequest.post("/notifications/create", payload);
+  }
+};
+
+export default notificationAPI;

--- a/src/utils/apis/notification.ts
+++ b/src/utils/apis/notification.ts
@@ -2,15 +2,10 @@ import { authRequest } from "./common";
 import { ICreateNotification } from "../../types/apis";
 
 const notificationAPI = {
-  getNotificationList: async () => {
-    return authRequest.get("/notifications");
-  },
-  seenNotification: async () => {
-    return authRequest.get("/notifications/seen");
-  },
-  createNotification: async (payload: ICreateNotification) => {
-    return authRequest.post("/notifications/create", payload);
-  }
+  getNotificationList: () => authRequest.get("/notifications"),
+  seenNotification: () => authRequest.get("/notifications/seen"),
+  createNotification: (payload: ICreateNotification) =>
+    authRequest.post("/notifications/create", payload)
 };
 
 export default notificationAPI;

--- a/src/utils/apis/post.ts
+++ b/src/utils/apis/post.ts
@@ -1,24 +1,17 @@
 import { unauthRequest, authRequest } from "./common";
 
 const postAPI = {
-  getChannelPostList: async (channelId: string) => {
-    return unauthRequest.get(`/posts/channel/${channelId}`);
-  },
-  getUserPostList: async (authorId: string, payload) => {
-    return unauthRequest.get(`/posts/author/${authorId}`, payload);
-  },
-  createPost: async (formData: FormData) => {
-    return authRequest.post("/posts/create", formData);
-  },
-  getPostDetail: async (postId: string) => {
-    return unauthRequest.get(`/posts/${postId}`);
-  },
-  updatePost: async (formData: FormData) => {
-    return authRequest.put("/posts/update", formData);
-  },
-  deletePost: async (postId: string) => {
-    return authRequest.delete("/posts/delete", { data: { id: postId } });
-  }
+  getChannelPostList: (channelId: string) =>
+    unauthRequest.get(`/posts/channel/${channelId}`),
+  getUserPostList: (authorId: string, payload) =>
+    unauthRequest.get(`/posts/author/${authorId}`, payload),
+  createPost: (formData: FormData) =>
+    authRequest.post("/posts/create", formData),
+  getPostDetail: (postId: string) => unauthRequest.get(`/posts/${postId}`),
+  updatePost: (formData: FormData) =>
+    authRequest.put("/posts/update", formData),
+  deletePost: (postId: string) =>
+    authRequest.delete("/posts/delete", { data: { id: postId } })
 };
 
 export default postAPI;

--- a/src/utils/apis/post.ts
+++ b/src/utils/apis/post.ts
@@ -1,0 +1,24 @@
+import { unauthRequest, authRequest } from "./common";
+
+const postAPI = {
+  getChannelPostList: async (channelId: string) => {
+    return unauthRequest.get(`/posts/channel/${channelId}`);
+  },
+  getUserPostList: async (authorId: string, payload) => {
+    return unauthRequest.get(`/posts/author/${authorId}`, payload);
+  },
+  createPost: async (formData: FormData) => {
+    return authRequest.post("/posts/create", formData);
+  },
+  getPostDetail: async (postId: string) => {
+    return unauthRequest.get(`/posts/${postId}`);
+  },
+  updatePost: async (formData: FormData) => {
+    return authRequest.put("/posts/update", formData);
+  },
+  deletePost: async (postId: string) => {
+    return authRequest.delete("/posts/delete", { data: { id: postId } });
+  }
+};
+
+export default postAPI;

--- a/src/utils/apis/search.ts
+++ b/src/utils/apis/search.ts
@@ -1,0 +1,12 @@
+import { unauthRequest } from "./common";
+
+const searchAPI = {
+  searchUsers: async (fullName: string) => {
+    return unauthRequest.get(`/search/users/${fullName}`);
+  },
+  searchAll: async (keyword: string) => {
+    return unauthRequest.get(`/search/all/${keyword}`);
+  }
+};
+
+export default searchAPI;

--- a/src/utils/apis/search.ts
+++ b/src/utils/apis/search.ts
@@ -1,12 +1,9 @@
 import { unauthRequest } from "./common";
 
 const searchAPI = {
-  searchUsers: async (fullName: string) => {
-    return unauthRequest.get(`/search/users/${fullName}`);
-  },
-  searchAll: async (keyword: string) => {
-    return unauthRequest.get(`/search/all/${keyword}`);
-  }
+  searchUsers: (fullName: string) =>
+    unauthRequest.get(`/search/users/${fullName}`),
+  searchAll: (keyword: string) => unauthRequest.get(`/search/all/${keyword}`)
 };
 
 export default searchAPI;

--- a/src/utils/apis/setting.ts
+++ b/src/utils/apis/setting.ts
@@ -1,0 +1,13 @@
+import { authRequest } from "./common";
+import { IChangInfo } from "../../types/apis";
+
+const settingAPI = {
+  changeInfo: (payload: IChangInfo) => {
+    return authRequest.put("/settings/update-user", payload);
+  },
+  changePwd: (password: string) => {
+    return authRequest.put("/settings/update-password", { password });
+  }
+};
+
+export default settingAPI;

--- a/src/utils/apis/setting.ts
+++ b/src/utils/apis/setting.ts
@@ -2,12 +2,10 @@ import { authRequest } from "./common";
 import { IChangInfo } from "../../types/apis";
 
 const settingAPI = {
-  changeInfo: (payload: IChangInfo) => {
-    return authRequest.put("/settings/update-user", payload);
-  },
-  changePwd: (password: string) => {
-    return authRequest.put("/settings/update-password", { password });
-  }
+  changeInfo: (payload: IChangInfo) =>
+    authRequest.put("/settings/update-user", payload),
+  changePwd: (password: string) =>
+    authRequest.put("/settings/update-password", { password })
 };
 
 export default settingAPI;

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -1,0 +1,34 @@
+import { unauthRequest, authRequest } from "./common";
+
+const userAPI = {
+  getUserList: async () => {
+    return unauthRequest.get("/users/get-users");
+  },
+  getOnlineUserList: async () => {
+    return unauthRequest.get("/users/online-users");
+  },
+  getUser: async (id: string) => {
+    return unauthRequest.get(`/users/${id}`);
+  },
+  changeProfileImage: async (formData: FormData) => {
+    // 이미지 formData만 담아서 인수로 전달
+    formData.append("isCover", "false");
+
+    return authRequest.post("/users/upload-photo", formData, {
+      headers: {
+        "Content-Type": "multipart/form-data"
+      }
+    });
+  },
+  changeCoverImage: async (formData: FormData) => {
+    formData.append("isCover", "true");
+
+    return authRequest.post("/users/upload-photo", formData, {
+      headers: {
+        "Content-Type": "multipart/form-data"
+      }
+    });
+  }
+};
+
+export default userAPI;

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -1,16 +1,10 @@
 import { unauthRequest, authRequest } from "./common";
 
 const userAPI = {
-  getUserList: async () => {
-    return unauthRequest.get("/users/get-users");
-  },
-  getOnlineUserList: async () => {
-    return unauthRequest.get("/users/online-users");
-  },
-  getUser: async (id: string) => {
-    return unauthRequest.get(`/users/${id}`);
-  },
-  changeProfileImage: async (formData: FormData) => {
+  getUserList: () => unauthRequest.get("/users/get-users"),
+  getOnlineUserList: () => unauthRequest.get("/users/online-users"),
+  getUser: (id: string) => unauthRequest.get(`/users/${id}`),
+  changeProfileImage: (formData: FormData) => {
     // 이미지 formData만 담아서 인수로 전달
     formData.append("isCover", "false");
 
@@ -20,7 +14,7 @@ const userAPI = {
       }
     });
   },
-  changeCoverImage: async (formData: FormData) => {
+  changeCoverImage: (formData: FormData) => {
     formData.append("isCover", "true");
 
     return authRequest.post("/users/upload-photo", formData, {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,27 @@
+const storage = {
+  getItem: <T>(key: string, initialValue: T) => {
+    try {
+      const value = localStorage.getItem(key);
+      return JSON.parse(value);
+    } catch (error) {
+      console.error(error);
+      return initialValue;
+    }
+  },
+  setItem: <T>(key: string, value: T) => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.error(error);
+    }
+  },
+  removeItem: (key: string) => {
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+};
+
+export default storage;


### PR DESCRIPTION
# 개요
API 구현

# 작업 내용
메시지 API는 당장 필요하지 않아서 추가하지 않았습니다.
- JWT 토큰이 필요한 API
  - 요청 전에 인터셉터를 이용해 우선 로컬 스토리지에 저장된 `TOKEN`키 값을 사용해 요청하도록 구현했습니다.
  - 논의할 점
    - 현재 구현된 것처럼 API에서 토큰을 자동으로 추가할지 API 인수로 토큰을 전달받을지
    - 토큰을 어디에 저장할지
      - 로컬 스토리지로 정해진다면, 키 값은 "TOKEN"이 괜찮은지  

# 관련 이슈
- 로그아웃 API는 현재 백엔드에서 제대로 동작하지 않고 있는 것 같습니다(?).
- 로그인, 사용자 검색, 인증 확인 API 만 테스트해보고 다른 API는 시간이 부족한 관계로 테스트하지 못 했습니다. 각자 페이지에서 사용해보시면서 API 에러가 발견되면 Issue로 알려주시면 감사하겠습니다🙇‍♀️
- 타입스크립트 인터페이스를 나름 작성해 봤는데 고칠 점이 있다면 알려주시면 감사하겠습니다!

# 사진

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #28 
