### PR TITLE
✨ feat: useClickAway 훅 추가

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,7 @@ module.exports = {
   stories: [
     "../src/components/**/*.stories.mdx",
     "../src/components/**/*.stories.@(js|jsx|ts|tsx)",
-    "../src/hooks/**/*.stories.@(js|jsx|ts|tsx)"
+    "../src/hooks/*.stories.@(js|jsx|ts|tsx)"
   ],
   addons: [
     "@storybook/preset-create-react-app",

--- a/src/hooks/useClickAway.stories.tsx
+++ b/src/hooks/useClickAway.stories.tsx
@@ -1,0 +1,31 @@
+import styled from "@emotion/styled";
+import { useState } from "react";
+import useClickAway from "./useClickAway";
+
+export default {
+  title: "Hook/useClickAway"
+};
+
+const Box = styled.div`
+  width: 700px;
+  height: 100px;
+  padding: 10px;
+  background-color: pink;
+`;
+
+export const Default = () => {
+  const [count, setCount] = useState(0);
+  const ref = useClickAway(() => setCount(count + 1));
+
+  return (
+    <Box ref={ref}>
+      <div style={{ display: "block", marginBottom: "10px", fontWeight: 700 }}>
+        상자(=ref) 바깥 영역 클릭 횟수: {count}
+      </div>
+      <div>
+        (상자 바깥 영역에서 발생하는 클릭 이벤트만 useClickAway 인수로 전달한
+        콜백함수가 호출됨!)
+      </div>
+    </Box>
+  );
+};

--- a/src/hooks/useClickAway.stories.tsx
+++ b/src/hooks/useClickAway.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import useClickAway from "./useClickAway";
 
 export default {
-  title: "Hook/useClickAway"
+  title: "Hooks/useClickAway"
 };
 
 const Box = styled.div`

--- a/src/hooks/useClickAway.ts
+++ b/src/hooks/useClickAway.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+
+const events = ["mousedown", "touchstart"];
+
+const useClickAway = (handler) => {
+  const ref = useRef(null);
+  const savedHandler = useRef(handler);
+
+  useEffect(() => {
+    savedHandler.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const handleEvent = (e: MouseEvent | TouchEvent) => {
+      if (!element.contains(e.target)) savedHandler.current(e);
+    };
+
+    events.forEach((eventName) =>
+      document.addEventListener(eventName, handleEvent)
+    );
+
+    return () => {
+      events.forEach((eventName) =>
+        document.removeEventListener(eventName, handleEvent)
+      );
+    };
+  }, [ref]);
+
+  return ref;
+};
+
+export default useClickAway;


### PR DESCRIPTION
# 개요
프로필 페이지 Modal 컴포넌트 구현을 위한 useClickAway 훅 추가
# 작업 내용
프로필 페이지에서만 사용될 것 같지만 따로 빼냈습니다. 

**인수**: 클릭 이벤트 핸들러
**반환값**: HTML 요소에 접근이 가능한 ref를 반환합니다

useClickAway는 모달 컴포넌트와 주로 같이 사용하는데 모달 영역 밖을 클릭했을 때 모달이 닫히는 기능 구현을 위해 사용됩니다. useClickAway 훅의 인수로 **모달이 닫히는 이벤트 핸들러**를 전달하고, 반환된 **ref를 속성을 모달에 설정**해서(=`ref={ref}`) 사용합니다.


# 관련 이슈

# 사진
![useClickAway](https://user-images.githubusercontent.com/96400112/173412273-d6a6065d-bc65-459e-a49e-e3df9d008c39.gif)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #104 
