### PR TITLE
✨ feat: ImageUpload 컴포넌트 구현

### DIFF
--- a/src/components/common/ImageUpload/ImageUpload.stories.tsx
+++ b/src/components/common/ImageUpload/ImageUpload.stories.tsx
@@ -1,0 +1,37 @@
+import { relative } from "path";
+import { useState } from "react";
+import ImageUpload from ".";
+
+export default {
+  title: "Component/ImageUpload",
+  component: ImageUpload
+};
+
+export const Default = () => {
+  const [file, setFile] = useState<File>(null);
+
+  return (
+    <>
+      <img src={file ? URL.createObjectURL(file) : ""} alt="" width="40%" />
+      <ImageUpload onImageUpload={(selectedFile) => setFile(selectedFile)} />
+    </>
+  );
+};
+
+export const Replacement = () => {
+  const [file, setFile] = useState<File>(null);
+
+  return (
+    <>
+      <img src={file ? URL.createObjectURL(file) : ""} alt="" width="40%" />
+      <ImageUpload
+        onImageUpload={(selectedFile) => setFile(selectedFile)}
+        replacement={
+          <span style={{ padding: "10px", backgroundColor: "royalblue" }}>
+            replacement
+          </span>
+        }
+      />
+    </>
+  );
+};

--- a/src/components/common/ImageUpload/index.tsx
+++ b/src/components/common/ImageUpload/index.tsx
@@ -1,0 +1,50 @@
+import React, { useRef } from "react";
+interface ImageUploadProps {
+  onImageUpload: (file: File) => void;
+  replacement?: React.ReactNode;
+  replacementStyle?: React.CSSProperties;
+}
+
+const ImageUpload: React.FC<ImageUploadProps> = ({
+  onImageUpload,
+  replacement,
+  replacementStyle
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files.length === 0) return;
+
+    const firstFile = e.target.files[0];
+    if (!isImageFile(firstFile)) {
+      alert("이미지 파일이 아닙니다");
+
+      e.target.value = "";
+      return;
+    }
+
+    onImageUpload(firstFile);
+  };
+
+  return (
+    <>
+      <div
+        onClick={() => inputRef.current.click()}
+        style={{ ...replacementStyle }}
+      >
+        {replacement ? replacement : null}
+      </div>
+      <input
+        ref={inputRef}
+        style={{ display: replacement ? "none" : undefined }}
+        type="file"
+        accept="image/*"
+        onChange={handleChange}
+      />
+    </>
+  );
+};
+
+export default ImageUpload;
+
+const isImageFile = (file: File) => file.type.match("image/.*");

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -1,5 +1,6 @@
 import Icon from "./Icon";
 import ProfileImage from "./ProfileImage";
 import SkillIcon from "./SkillIcon";
+import ImageUpload from "./ImageUpload";
 
-export { Icon, ProfileImage, SkillIcon };
+export { Icon, ProfileImage, SkillIcon, ImageUpload };


### PR DESCRIPTION
# 개요
ImageUpload 공통 컴포넌트 구현

# 작업 내용
프로필 페이지에서 사용할 용도로 만들다가 추후에 게시글 작성에서도 사용될 수 있을 것 같아 공통으로 뺐습니다.

## props
- onImageUpload
  - 이미지 파일이 선택되었을 때 호출될 콜백 함수이며, **인수로 선택된 이미지 파일(=File 타입)이 전달**됩니다. 
- replacement
  - input:file의 기본 스타일(= 아래의 UI)을 **커스텀**하기 위한 prop으로 대체할 **컴포넌트**를 전달하면 됩니다. 아래 스토리북 Replacement의 gif를 보시면 됩니다!
    ![image](https://user-images.githubusercontent.com/96400112/173534152-7108a630-642d-4769-acfa-21606563dc8a.png)
- replacementStyle
  - 프로필 페이지에서 사용할 목적으로 넣은 prop입니다.
    - 프로필 페이지에서는 ImageUpload 컴포넌트가 ProfileImage 컴포넌트와 겹치게 올려야 해서 `position: absolute, top: ~, left: ~` 스타일 적용을 위해 넣었습니다.
    ![image](https://user-images.githubusercontent.com/96400112/173534820-5fd975ba-8162-4d89-beff-848dda00a8ce.png)

# 관련 이슈
- props.replacementStyle을  `position: absolute, top: ~, left: ~` 용도로 넣어서 다른 css 속성도 잘 적용될지 미지수입니다..
  - 프로필 페이지를 위해 넣은 prop이 있어서 공통 컴포넌트라고 칭하기가 불편하네요🙄

# 사진
⚠ImageUpload 컴포넌트는 input:file 역할만 합니다. 선택된 이미지를 보여주는 것은 스토리북 이해를 위해서 넣은 별도의 기능입니다.

**스토리북 Default** 
![imageUpload default](https://user-images.githubusercontent.com/96400112/173532653-76fe487e-383b-4c5d-8134-fc769faea150.gif)

**스토리북 Replacement**
![imageUpload replacement](https://user-images.githubusercontent.com/96400112/173532724-926f1767-353d-4327-9d89-ff331f2b3535.gif)


<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #108 