### PR TITLE
🐛 fix: path alias 설정이 적용되지 않던 문제

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,18 +1,15 @@
 /* eslint-disable no-undef */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const path = require("path");
+const { CracoAliasPlugin } = require("react-app-alias");
 
 module.exports = {
   babel: {
     presets: ["@emotion/babel-preset-css-prop"]
   },
-  webpack: {
-    alias: {
-      "@assets": path.resolve(__dirname, "src/assets"),
-      "@components": path.resolve(__dirname, "src/components"),
-      "@hooks": path.resolve(__dirname, "src/hooks"),
-      "@contexts": path.resolve(__dirname, "src/contexts"),
-      "@pages": path.resolve(__dirname, "src/pages")
+  plugins: [
+    {
+      plugin: CracoAliasPlugin,
+      options: {}
     }
-  }
+  ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "husky": "^8.0.1",
         "prettier": "^2.6.2",
         "prop-types": "^15.8.1",
+        "react-app-alias": "^2.2.0",
         "webpack": "^5.73.0"
       }
     },
@@ -26690,6 +26691,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-app-alias": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-app-alias/-/react-app-alias-2.2.0.tgz",
+      "integrity": "sha512-LaDIn+mbhimcvatV1DiBjh+8Lg6f3shEWqwy6IywfT3J3IIiEOTncChEYWTrnIvV9R97bRQoL9a95uAOQipyTA==",
+      "dev": true
+    },
     "node_modules/react-app-polyfill": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz",
@@ -52191,6 +52198,12 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "react-app-alias": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-app-alias/-/react-app-alias-2.2.0.tgz",
+      "integrity": "sha512-LaDIn+mbhimcvatV1DiBjh+8Lg6f3shEWqwy6IywfT3J3IIiEOTncChEYWTrnIvV9R97bRQoL9a95uAOQipyTA==",
+      "dev": true
     },
     "react-app-polyfill": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "husky": "^8.0.1",
     "prettier": "^2.6.2",
     "prop-types": "^15.8.1",
+    "react-app-alias": "^2.2.0",
     "webpack": "^5.73.0"
   }
 }

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -1,6 +1,5 @@
-import Icon from "../Icon";
-import githubIcon from "../../../assets/icons/icon_github.svg";
-import youtubeIcon from "../../../assets/icons/icon_youtube.svg";
+import githubIcon from "@assets/icons/icon_github.svg";
+import youtubeIcon from "@assets/icons/icon_youtube.svg";
 import * as S from "./style";
 
 const Footer = () => {

--- a/src/components/common/SkillIcon/index.tsx
+++ b/src/components/common/SkillIcon/index.tsx
@@ -1,4 +1,4 @@
-import { useHover } from "../../../hooks";
+import { useHover } from "@hooks";
 import * as S from "./style";
 
 interface SkillIconInterface {

--- a/src/components/profile/CoverImage/index.tsx
+++ b/src/components/profile/CoverImage/index.tsx
@@ -1,5 +1,5 @@
 import * as S from "./style";
-import defaultCoverImage from "../../../assets/imgs/profile_default_cover.png";
+import defaultCoverImage from "@assets/imgs/profile_default_cover.png";
 
 interface ICoverImage {
   imgSrc?: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "es5",
-    "typeRoots" : ["./@types", "./node_modules/@types"],
+    "typeRoots": ["./@types", "./node_modules/@types"],
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@assets": ["src/assets"],
+      "@components": ["src/components"],
+      "@constants": ["src/constants"],
+      "@contexts": ["src/contexts"],
+      "@hooks": ["src/hooks"],
+      "@pages": ["src/pages"],
+      "@utils": ["src/utils"]
+    }
+  }
+}


### PR DESCRIPTION
# 개요
path alias 설정이 적용되지 않던 문제
# 작업 내용
**CRA** + craco + typescript 환경에서는 [react-app-alias](https://github.com/oklas/react-app-alias#using-craco) 패키지를 이용해 path alias를 설정해야 하더군요..새로운 패키지를 설치해서 해당 브랜치가 머지되면 `npm i` 한 번 해주셔야 제대로 path alias를 사용하실 수 있을 것이에요!

`@assets`, `@components`, `@constants`, `@contexts`, `@hooks`, `@pages`, `@utils `추가 했습니다. 

# 관련 이슈
- `@types`, `@styles` 별칭도 만들고 싶었으나 기존 패키지와 겹쳐서 설정하지 못 했습니다😅

# 사진

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #102 