### PR TITLE
✨ feat: Modal 컴포넌트 구현

### DIFF
--- a/src/assets/icons/icon_close.svg
+++ b/src/assets/icons/icon_close.svg
@@ -1,0 +1,4 @@
+<svg width="31" height="31" viewBox="0 0 31 31" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M23.25 7.75L7.75 23.25" stroke="#312F2F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M7.75 7.75L23.25 23.25" stroke="#312F2F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/components/profile/Modal/Modal.stories.tsx
+++ b/src/components/profile/Modal/Modal.stories.tsx
@@ -1,0 +1,21 @@
+import Modal from ".";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { useState } from "react";
+
+export default {
+  title: "Page/Modal",
+  component: Modal
+} as ComponentMeta<typeof Modal>;
+
+export const Default: ComponentStory<typeof Modal> = () => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setVisible(true)}>모달 얍</button>
+      <Modal onClose={() => setVisible(false)} height="300px" visible={visible}>
+        모달
+      </Modal>
+    </>
+  );
+};

--- a/src/components/profile/Modal/index.tsx
+++ b/src/components/profile/Modal/index.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useMemo } from "react";
+import ReactDOM from "react-dom";
+import { useClickAway } from "../../../hooks";
+import * as S from "./style";
+import closeSvg from "../../../assets/icons/icon_close.svg";
+
+interface ModalInterface {
+  children: React.ReactNode;
+  height: string;
+  visible: boolean;
+  onClose: () => void;
+}
+
+export const Modal: React.FC<ModalInterface> = ({
+  children,
+  height,
+  visible = false,
+  onClose,
+  ...props
+}) => {
+  const ref = useClickAway(() => {
+    onClose();
+  });
+
+  const el = useMemo(() => document.createElement("div"), []);
+  useEffect(() => {
+    document.body.appendChild(el);
+    return () => {
+      document.body.removeChild(el);
+    };
+  });
+
+  return ReactDOM.createPortal(
+    <S.BackgroundDim visible={visible}>
+      <S.ModalContainer ref={ref} height={height} {...props}>
+        <S.CloseButton onClick={onClose}>
+          <img src={closeSvg} alt="닫기 버튼" />
+        </S.CloseButton>
+        {children}
+      </S.ModalContainer>
+    </S.BackgroundDim>,
+    el
+  );
+};
+
+export default Modal;

--- a/src/components/profile/Modal/style.tsx
+++ b/src/components/profile/Modal/style.tsx
@@ -1,0 +1,36 @@
+import styled from "@emotion/styled";
+
+export const BackgroundDim = styled.div<{ visible: boolean }>`
+  display: ${({ visible }) => (visible ? "block" : "none")};
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+`;
+
+export const ModalContainer = styled.div<{ height: string }>`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 461px;
+  height: ${({ height }) => height};
+  border-radius: 8px;
+  padding: 43px 40px 59px;
+  background-color: #fff;
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+  box-sizing: border-box;
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  top: 38px;
+  right: 40px;
+  border: none;
+  padding: 0;
+  background-color: transparent;
+  cursor: pointer;
+`;

--- a/src/components/profile/index.tsx
+++ b/src/components/profile/index.tsx
@@ -1,2 +1,4 @@
 import CoverImage from "./CoverImage";
-export { CoverImage };
+import Modal from "./Modal";
+
+export { CoverImage, Modal };

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,3 +1,4 @@
 import useHover from "./useHover";
+import useClickAway from "./useClickAway";
 
-export { useHover };
+export { useHover, useClickAway };


### PR DESCRIPTION
# 개요
프로필 페이지에 사용될 Modal 컴포넌트를 구현했습니다.

# 작업 내용
## props
- children
  - 모달 안에 들어갈 컴포넌트들입니다.
- height
  - 모달의 높이입니다. 문자열로 받기 때문에 px, % 모두 사용 가능합니다.
- visible
  - 배경과 모달의 display 값을 block, none 으로 토글하는 불리언 값입니다.
- onClose
  - 모달 영역 밖을 클릭하거나 모달 내 X 버튼을 누를 때 호출되는 콜백 함수입니다.

# 관련 이슈

# 사진
**스토리북 Default**
![Modal](https://user-images.githubusercontent.com/96400112/173681336-d5bb2b41-a1a0-403c-93e0-2a4427aa91a5.gif)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #101 