### PR TITLE
✨ feat: Tab 컴포넌트 구현

### DIFF
--- a/src/components/profile/Tab/TabItem.tsx
+++ b/src/components/profile/Tab/TabItem.tsx
@@ -4,7 +4,6 @@ export interface TabItemInterface {
   children: React.ReactNode;
   title: string;
   active?: boolean;
-  index: number;
   onClick?: () => void;
 }
 

--- a/src/components/profile/Tab/TabItem.tsx
+++ b/src/components/profile/Tab/TabItem.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import * as S from "./style";
+export interface TabItemInterface {
+  children: React.ReactNode;
+  title: string;
+  active?: boolean;
+  index: number;
+  onClick?: () => void;
+}
+
+const TabItem: React.FC<TabItemInterface> = ({
+  title,
+  active = false,
+  onClick,
+  ...props
+}) => {
+  return (
+    <>
+      <S.TabItem active={active} {...props} onClick={onClick ? onClick : null}>
+        {title}
+      </S.TabItem>
+    </>
+  );
+};
+
+export default TabItem;

--- a/src/components/profile/Tab/index.tsx
+++ b/src/components/profile/Tab/index.tsx
@@ -1,0 +1,50 @@
+import React, { ReactElement, useMemo, useState } from "react";
+import TabItem, { TabItemInterface } from "./TabItem";
+import * as S from "./style";
+
+interface TabInterface {
+  children: React.ReactNode;
+  active?: number;
+}
+
+type TabCompositionType = {
+  Item: typeof TabItem;
+};
+
+const Tab: React.FC<TabInterface> & TabCompositionType = ({
+  children,
+  active,
+  ...props
+}) => {
+  const [currentActive, setCurrentActive] = useState(active ? active : 0);
+
+  const tabItemList = useMemo(() => {
+    return React.Children.toArray(children).map(
+      (tabItem: ReactElement<TabItemInterface>) => {
+        return React.cloneElement(tabItem, {
+          ...tabItem.props,
+          key: tabItem.props.index,
+          active: tabItem.props.index === currentActive,
+          onClick: () => {
+            setCurrentActive(tabItem.props.index);
+          }
+        });
+      }
+    );
+  }, [children, currentActive]);
+
+  const activeTabItem = useMemo(
+    () => tabItemList.find((tabItem) => currentActive === tabItem.props.index),
+    [currentActive, tabItemList]
+  );
+
+  return (
+    <div>
+      <S.TabWrapper>{tabItemList}</S.TabWrapper>
+      <div>{activeTabItem.props.children}</div>
+    </div>
+  );
+};
+
+Tab.Item = TabItem;
+export default Tab;

--- a/src/components/profile/Tab/index.tsx
+++ b/src/components/profile/Tab/index.tsx
@@ -20,13 +20,13 @@ const Tab: React.FC<TabInterface> & TabCompositionType = ({
 
   const tabItemList = useMemo(() => {
     return React.Children.toArray(children).map(
-      (tabItem: ReactElement<TabItemInterface>) => {
+      (tabItem: ReactElement<TabItemInterface>, index) => {
         return React.cloneElement(tabItem, {
           ...tabItem.props,
-          key: tabItem.props.index,
-          active: tabItem.props.index === currentActive,
+          key: index,
+          active: index === currentActive,
           onClick: () => {
-            setCurrentActive(tabItem.props.index);
+            setCurrentActive(index);
           }
         });
       }
@@ -34,7 +34,7 @@ const Tab: React.FC<TabInterface> & TabCompositionType = ({
   }, [children, currentActive]);
 
   const activeTabItem = useMemo(
-    () => tabItemList.find((tabItem) => currentActive === tabItem.props.index),
+    () => tabItemList[currentActive],
     [currentActive, tabItemList]
   );
 

--- a/src/components/profile/Tab/style.tsx
+++ b/src/components/profile/Tab/style.tsx
@@ -1,0 +1,16 @@
+import styled from "@emotion/styled";
+import theme from "../../../styles/theme";
+
+export const TabItem = styled.div<{ active: boolean }>`
+  width: 150px;
+  border-bottom: 2px solid
+    ${({ active }) => (active ? theme.$red : theme.$gray200)};
+  padding: 4px;
+  text-align: center;
+  cursor: pointer;
+  box-sizing: border-box;
+`;
+
+export const TabWrapper = styled.div`
+  display: inline-flex;
+`;

--- a/src/components/profile/index.tsx
+++ b/src/components/profile/index.tsx
@@ -1,5 +1,6 @@
 import CoverImage from "./CoverImage";
 import Modal from "./Modal";
 import EditIcon from "./EditIcon";
+import Tab from "./Tab";
 
-export { CoverImage, Modal, EditIcon };
+export { CoverImage, Modal, EditIcon, Tab };

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -39,12 +39,10 @@ const Profile: React.FC = () => {
 
       <div style={{ display: "inline-flex" }}>
         <Tab>
-          <Tab.Item active title="작성한 글 목록" index={0}>
+          <Tab.Item active title="작성한 글 목록">
             작성한 글 목록 컨텐츠
           </Tab.Item>
-          <Tab.Item title="좋아요 한 글" index={1}>
-            좋아요 한 글 목록 컨텐츠
-          </Tab.Item>
+          <Tab.Item title="좋아요 한 글">좋아요 한 글 목록 컨텐츠</Tab.Item>
         </Tab>
       </div>
     </>

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useState } from "react";
 import { useParams } from "react-router";
-import { CoverImage, EditIcon } from "@components/profile";
+import { CoverImage, EditIcon, Tab } from "@components/profile";
 import { ProfileImage } from "@components/common";
 import * as S from "./style";
 
@@ -36,6 +36,17 @@ const Profile: React.FC = () => {
       <button onClick={() => setIsLoggedIn(!isLoggedIn)}>
         {isLoggedIn ? "로그아웃되는 척" : "로그인되는 척"}
       </button>
+
+      <div style={{ display: "inline-flex" }}>
+        <Tab>
+          <Tab.Item active title="작성한 글 목록" index={0}>
+            작성한 글 목록 컨텐츠
+          </Tab.Item>
+          <Tab.Item title="좋아요 한 글" index={1}>
+            좋아요 한 글 목록 컨텐츠
+          </Tab.Item>
+        </Tab>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
# 개요
페이지 이동 없이 콘텐츠를 스위칭할 수 있는 Tab 컴포넌트 구현 
# 작업 내용
- [x] TabItem 컴포넌트 구현
- [x] Tab 컴포넌트 구현

Tab컴포넌트의 currentActive 상태값에 따라 보여주는 콘텐츠와 TabItem의 props.active값이 변경됩니다.
# 관련 이슈

# 사진
![Tab](https://user-images.githubusercontent.com/96400112/174090039-4aa17f59-a8c7-44aa-a7f2-3cbea1b98ae4.gif)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
짝꿍 @NamgyungKim 🥰
closes #100 
