### PR TITLE
✨ feat: ProfileImageBox 컴포넌트 구현

### DIFF
--- a/src/components/profile/EditIcon/index.tsx
+++ b/src/components/profile/EditIcon/index.tsx
@@ -4,16 +4,14 @@ import * as S from "./style";
 interface EditIconInterface {
   bottom?: string;
   right?: string;
-  onClick: React.MouseEventHandler;
 }
 
 const EditIcon: React.FC<EditIconInterface> = ({
   bottom = "0",
-  right = "0",
-  onClick
+  right = "0"
 }) => {
   return (
-    <S.EditWrapper bottom={bottom} right={right} onClick={onClick}>
+    <S.EditWrapper bottom={bottom} right={right}>
       <EditComponent width="16px" height="16px" />
     </S.EditWrapper>
   );

--- a/src/components/profile/ProfileImageBox/index.tsx
+++ b/src/components/profile/ProfileImageBox/index.tsx
@@ -1,0 +1,42 @@
+import { FC, useState } from "react";
+import { ProfileImage, ImageUpload } from "@components/common";
+import { EditIcon } from "@components/profile";
+import * as S from "./style";
+import { userAPI } from "@utils/apis";
+
+interface ProfileImageBoxInterface {
+  isMine: boolean;
+  imgSrc: string;
+}
+
+const ProfileImageBox: FC<ProfileImageBoxInterface> = ({ isMine, imgSrc }) => {
+  const [src, setSrc] = useState(imgSrc);
+
+  const handleImageUpload = async (file) => {
+    const formData = new FormData();
+    formData.append("image", file);
+
+    // try {
+    //   const response = await userAPI.changeProfileImage(formData);
+
+    //   console.log(response.data);
+    //   setSrc(response.data.image);
+    // } catch (error) {
+    //   console.error(error);
+    // }
+  };
+
+  return (
+    <S.ProfileImageWrapper>
+      <ProfileImage imgSrc={src} size="lg" />
+      {isMine ? (
+        <ImageUpload
+          onImageUpload={handleImageUpload}
+          replacement={<EditIcon right="-3px" />}
+        />
+      ) : null}
+    </S.ProfileImageWrapper>
+  );
+};
+
+export default ProfileImageBox;

--- a/src/components/profile/ProfileImageBox/style.tsx
+++ b/src/components/profile/ProfileImageBox/style.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const ProfileImageWrapper = styled.div`
+  position: relative;
+  width: 80px;
+  height: 80px;
+`;

--- a/src/components/profile/index.tsx
+++ b/src/components/profile/index.tsx
@@ -1,5 +1,6 @@
 import CoverImage from "./CoverImage";
 import Modal from "./Modal";
 import EditIcon from "./EditIcon";
+import ProfileImageBox from "./ProfileImageBox";
 
-export { CoverImage, Modal, EditIcon };
+export { CoverImage, Modal, EditIcon, ProfileImageBox };

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,40 +1,22 @@
 import React from "react";
 import { useState } from "react";
 import { useParams } from "react-router";
-import { CoverImage, EditIcon } from "@components/profile";
-import { ProfileImage } from "@components/common";
-import * as S from "./style";
+import { ProfileImageBox } from "@components/profile";
 
 const Profile: React.FC = () => {
   const { id } = useParams<Record<string, string>>();
-
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
   const user = DUMMY_USER;
+
+  const [isMine, setIsMine] = useState(false);
 
   return (
     <>
       <h1>Profile id_: {id}</h1>
 
-      <S.CoverImageWrapper>
-        <CoverImage
-          imgSrc={user.coverImage}
-          imgAlt={`${user.fullName}님의 커버 이미지`}
-        />
-        {isLoggedIn ? (
-          <EditIcon bottom="9px" right="20%" onClick={() => alert("Click!")} />
-        ) : null}
-      </S.CoverImageWrapper>
+      <ProfileImageBox isMine={isMine} imgSrc={user.image} />
 
-      <S.ProfileImageWrapper>
-        <ProfileImage imgSrc={user.image} size="lg" />
-        {isLoggedIn ? (
-          <EditIcon right="-3px" onClick={() => alert("Click!")} />
-        ) : null}
-      </S.ProfileImageWrapper>
-
-      <button onClick={() => setIsLoggedIn(!isLoggedIn)}>
-        {isLoggedIn ? "로그아웃되는 척" : "로그인되는 척"}
+      <button onClick={() => setIsMine(!isMine)}>
+        {isMine ? "다른 사람인 척" : "내 프로필인 척"}
       </button>
     </>
   );
@@ -62,7 +44,7 @@ const DUMMY_USER = {
   __v: 0,
   username: "유현naver",
   image:
-    "https://res.cloudinary.com/learnprogrammers/image/upload/v1655058232/user/6ecb4177-78ea-4362-96a4-e95903a6e84a.png",
+    "https://res.cloudinary.com/learnprogrammers/image/upload/v1655428928/user/7128b331-10d5-4771-b33f-afa6448b64bd.png",
   imagePublicId: "user/6ecb4177-78ea-4362-96a4-e95903a6e84a",
   coverImage:
     "https://res.cloudinary.com/learnprogrammers/image/upload/v1655058503/user/99bff83a-15db-4b49-bedc-7ae907aebbbe.jpg",

--- a/src/pages/profile/style.tsx
+++ b/src/pages/profile/style.tsx
@@ -1,13 +1,1 @@
 import styled from "@emotion/styled";
-
-export const CoverImageWrapper = styled.div`
-  position: relative;
-  width: 100%;
-  height: 100%;
-`;
-
-export const ProfileImageWrapper = styled.div`
-  position: relative;
-  width: 80px;
-  height: 80px;
-`;


### PR DESCRIPTION
# 개요
프로필 페이지에서 사용할 CoverImageBox 컴포넌트 구현
# 작업 내용
- [x] EditIcon 컴포넌트를 ImageUpload 컴포넌트의 replacement로 사용
- [x] EditIcon 컴포넌트 클릭 시 ImageUpload 컴포넌트를 클릭하도록 연결
- [x] 추후 API 통신에 사용할 수 있도록 선택된 이미지 파일 formData에 담기
- [x] ProfileImageBox 컴포넌트로 추출 (#99)
- [x] API 통신 연결 

# 관련 이슈
- 서버 통신하는 동안 로딩 중임을 알리는 스켈레톤 컴포넌트가 필요해 보입니다. 
  - isLoading 변수를 #151 로 관리해야 할 것 같습니다.
- 우선 서버 통신 기능을 해당 컴포넌트 내부에 작성했지만, 프로필 이미지가 변경되면 #151 값이 변경되는 것과 같으므로 action에서 해야 할 것 같습니다.
  - 서버 통신은 현재 주석 처리를 해서 제대로 동작하지 않습니다. 기능을 테스트하려면 components/profile/ProfileImageBox/index.tsx 파일에서 주석을 제거해야 할 수 있습니다.

# 사진
⚠아래 gif는 CoverImageBox 컴포넌트 구현이 끝난 상태로 촬영해 커버 이미지가 보이지만 현재 PR 날리는 코드 상으로는 CoverImageBox 컴포넌트 구현 전이라 커버 이미지가 없습니다!!
![ProfileImageBox](https://user-images.githubusercontent.com/96400112/174212500-04949bfc-ef4d-4263-b03f-dcfaadeb527c.gif)


<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #144 
