### PR TITLE
✨ feat: CoverImageBox 컴포넌트 구현

### DIFF
--- a/src/components/profile/CoverImageBox/index.tsx
+++ b/src/components/profile/CoverImageBox/index.tsx
@@ -1,0 +1,41 @@
+import { FC, useState } from "react";
+import { ImageUpload } from "@components/common";
+import { CoverImage, EditIcon } from "@components/profile";
+import { userAPI } from "@utils/apis";
+import * as S from "./style";
+
+interface CoverImageBoxInterface {
+  isMine: boolean;
+  imgSrc: string;
+}
+
+const CoverImageBox: FC<CoverImageBoxInterface> = ({ isMine, imgSrc }) => {
+  const [src, setSrc] = useState(imgSrc);
+
+  const handleImageUpload = async (file) => {
+    const formData = new FormData();
+    formData.append("image", file);
+
+    try {
+      const response = await userAPI.changeCoverImage(formData);
+
+      setSrc(response.data.coverImage);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <S.CoverImageWrapper>
+      <CoverImage imgSrc={src} />
+      {isMine ? (
+        <ImageUpload
+          onImageUpload={handleImageUpload}
+          replacement={<EditIcon bottom="9px" right="20%" />}
+        />
+      ) : null}
+    </S.CoverImageWrapper>
+  );
+};
+
+export default CoverImageBox;

--- a/src/components/profile/CoverImageBox/style.tsx
+++ b/src/components/profile/CoverImageBox/style.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const CoverImageWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;

--- a/src/components/profile/ProfileImageBox/index.tsx
+++ b/src/components/profile/ProfileImageBox/index.tsx
@@ -1,8 +1,8 @@
 import { FC, useState } from "react";
 import { ProfileImage, ImageUpload } from "@components/common";
 import { EditIcon } from "@components/profile";
-import * as S from "./style";
 import { userAPI } from "@utils/apis";
+import * as S from "./style";
 
 interface ProfileImageBoxInterface {
   isMine: boolean;
@@ -16,14 +16,13 @@ const ProfileImageBox: FC<ProfileImageBoxInterface> = ({ isMine, imgSrc }) => {
     const formData = new FormData();
     formData.append("image", file);
 
-    // try {
-    //   const response = await userAPI.changeProfileImage(formData);
+    try {
+      const response = await userAPI.changeProfileImage(formData);
 
-    //   console.log(response.data);
-    //   setSrc(response.data.image);
-    // } catch (error) {
-    //   console.error(error);
-    // }
+      setSrc(response.data.image);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (

--- a/src/components/profile/index.tsx
+++ b/src/components/profile/index.tsx
@@ -1,7 +1,8 @@
 import CoverImage from "./CoverImage";
+import CoverImageBox from "./CoverImageBox";
 import Modal from "./Modal";
 import EditIcon from "./EditIcon";
 import Tab from "./Tab";
 import ProfileImageBox from "./ProfileImageBox";
 
-export { CoverImage, Modal, EditIcon, ProfileImageBox, Tab };
+export { CoverImage, CoverImageBox, Modal, EditIcon, ProfileImageBox, Tab };

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,14 +1,6 @@
-import React from "react";
-import { useState } from "react";
+import React, { useState } from "react";
 import { useParams } from "react-router";
-import {
-  CoverImage,
-  EditIcon,
-  Tab,
-  ProfileImageBox
-} from "@components/profile";
-import { ProfileImage } from "@components/common";
-import * as S from "./style";
+import { Tab, ProfileImageBox, CoverImageBox } from "@components/profile";
 
 const Profile: React.FC = () => {
   const { id } = useParams<Record<string, string>>();
@@ -20,6 +12,7 @@ const Profile: React.FC = () => {
     <>
       <h1>Profile id_: {id}</h1>
 
+      <CoverImageBox isMine={isMine} imgSrc={user.coverImage} />
       <ProfileImageBox isMine={isMine} imgSrc={user.image} />
 
       <button onClick={() => setIsMine(!isMine)}>


### PR DESCRIPTION
# 개요
프로필 페이지 CoverImageBox 컴포넌트 구현
# 작업 내용
- CoverImage (커버 이미지 출력) + ImageUpload (이미지 파일 받기) + EditIcon (ImageUpload의 input:file 스타일 덮어쓰기) 컴포넌트들의 조합으로 만들었습니다.
- `커버 이미지 변경` 서버 통신 연결 (UserContext로 이관할 예정)

# 관련 이슈
- ProfileImageBox 컴포넌트 코드와 거의 유사해서..마음이 불편하지만 추후에 시간이 된다면 리팩토링하겠습니다
- User 정보를 받아오는 서버 통신은 연결하지 않고 더미 데이터로 하기 때문에 첫 페이지에 보이는 커버 이미지는 실제 유저의 커버 이미지와 다를 수 있습니다

# 사진
![CoverImageBox](https://user-images.githubusercontent.com/96400112/174300016-47973e86-7891-4342-8add-1efb4dcf01e6.gif)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #159 

짝꿍 @NamgyungKim 