### PR TITLE
🐛 fix: getItem, removeItem 불필요한 에러 핸들링 제거

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,12 +1,8 @@
 const storage = {
   getItem: <T>(key: string, initialValue: T) => {
-    try {
-      const value = localStorage.getItem(key);
-      return JSON.parse(value);
-    } catch (error) {
-      console.error(error);
-      return initialValue;
-    }
+    const value = localStorage.getItem(key);
+
+    return value === null ? initialValue : JSON.parse(value);
   },
   setItem: <T>(key: string, value: T) => {
     try {
@@ -16,11 +12,7 @@ const storage = {
     }
   },
   removeItem: (key: string) => {
-    try {
-      localStorage.removeItem(key);
-    } catch (error) {
-      console.error(error);
-    }
+    localStorage.removeItem(key);
   }
 };
 


### PR DESCRIPTION
# 개요
로컬 스토리지의 getItem, removeItem 메서드에 대한 지식이 잘못된 상태에서 구현했습니다.

- getItem
  - 실제 로컬 스토리지의 `getItem` 메서드는 인수로 전달하는 키 값이 없으면, 에러를 발생시키지 않고 `null` 값을 반환
- removeItem
  - 실제 로컬 스토리지의 `removeItem` 메서드는 인수로 전달하는 키 값이 없어도 에러 발생 X
# 작업 내용
- getItem 인수로 전달하는 key 값이 없으면 initialValue를 반환하도록 변경
- removeItem 함수 내부에 실행될 수 없는 에러 핸들링 제거

# 관련 이슈

# 사진

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #189 