### PR TITLE
✨ feat: useAxiosFn, useAxios 훅 구현

### DIFF
--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,4 +1,4 @@
-import useHover from "./useHover";
-import useClickAway from "./useClickAway";
-
-export { useHover, useClickAway };
+export { default as useAxios } from "./useAxios";
+export { default as useAxiosFn } from "./useAxiosFn";
+export { default as useClickAway } from "./useClickAway";
+export { default as useHover } from "./useHover";

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,0 +1,14 @@
+import { useEffect, DependencyList } from "react";
+import useAxiosFn, { AxiosFunction } from "./useAxiosFn";
+
+const useAxios = (axiosFn: AxiosFunction, deps: DependencyList) => {
+  const [state, callback] = useAxiosFn(axiosFn, deps);
+
+  useEffect(() => {
+    callback();
+  }, [callback]);
+
+  return state;
+};
+
+export default useAxios;

--- a/src/hooks/useAxiosFn.ts
+++ b/src/hooks/useAxiosFn.ts
@@ -1,0 +1,46 @@
+import { AxiosError, AxiosResponse } from "axios";
+import { DependencyList, useCallback, useRef, useState } from "react";
+
+export type AxiosState = {
+  isLoading: boolean;
+  error?: AxiosError;
+  response?: AxiosResponse;
+};
+
+export type AxiosFunction = (...args: any) => Promise<AxiosResponse>;
+
+const useAxiosFn = (
+  axiosFn: AxiosFunction,
+  deps: DependencyList
+): [AxiosState, AxiosFunction] => {
+  const lastCallId = useRef(0);
+  const [state, setState] = useState<AxiosState>({
+    isLoading: false
+  });
+
+  const callback = useCallback((...args) => {
+    const callId = ++lastCallId.current;
+
+    if (!state.isLoading) {
+      setState({ ...state, isLoading: true });
+    }
+
+    return axiosFn(...args)
+      .then((response) => {
+        if (callId === lastCallId.current) {
+          setState({ response, isLoading: false });
+          return response;
+        }
+      })
+      .catch((error) => {
+        if (callId === lastCallId.current) {
+          setState({ error, isLoading: false });
+          return error;
+        }
+      });
+  }, deps);
+
+  return [state, callback];
+};
+
+export default useAxiosFn;


### PR DESCRIPTION
# 개요
서버 통신에 사용할 useAxiosFn, useAxios 훅 구현
# 작업 내용
- useAxiosFn
  - 반환되는 axios 함수의 콜백 함수를 서버 통신이 필요한 때에 맞게 호출하면 됨
  - axios 함수를 첫번째 인수로 전달
  - 두번째 인수로 의존성 전달
  - 반환값
    - [ { isLoading, response, error }, axios 함수의 콜백 함수 반환 ]

- useAxios
  - **페이지가 마운트 될 때** 인수로 전달한 axios 함수를 한 번 실행되는 훅
  - { isLoading, response, error } 값 반환
  - 두번째 인수로 의존성 전달
# 관련 이슈

# 사진
## useAxiosFn 사용 예시
![useAxiosFn](https://user-images.githubusercontent.com/96400112/174464989-c0089d93-282b-4ae5-be51-e45725a13d33.gif)

![useaxiosFn](https://user-images.githubusercontent.com/96400112/174464960-9ad3741a-5e60-4cd9-9fb8-33f5db87e46d.PNG)

## useAxios 사용 예시
![useAxios](https://user-images.githubusercontent.com/96400112/174464967-93067943-bb6e-4a9e-a93b-dd97a2bc297a.gif)

![useAxios](https://user-images.githubusercontent.com/96400112/174465014-a845b9e8-96f1-41c5-8540-5e18057d2bb4.PNG)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #188 