### PR TITLE
🐛 fix: 서버 API 오류

### DIFF
--- a/src/types/apis.ts
+++ b/src/types/apis.ts
@@ -30,3 +30,8 @@ export interface ICreateNotification {
   userId: string;
   postId?: string;
 }
+
+export interface IOffsetLimit {
+  offset?: number;
+  limit?: number;
+}

--- a/src/utils/apis/follow.ts
+++ b/src/utils/apis/follow.ts
@@ -3,8 +3,8 @@ import { authRequest } from "./common";
 const followAPI = {
   createFollow: (userId: string) =>
     authRequest.post("/follow/create", { userId }),
-  deleteFollow: (userId: string) =>
-    authRequest.delete("/follow/delete", { data: { id: userId } })
+  deleteFollow: (followId: string) =>
+    authRequest.delete("/follow/delete", { data: { id: followId } })
 };
 
 export default followAPI;

--- a/src/utils/apis/like.ts
+++ b/src/utils/apis/like.ts
@@ -2,8 +2,8 @@ import { authRequest } from "./common";
 
 const likeAPI = {
   createLike: (postId: string) => authRequest.post("/likes/create", { postId }),
-  deleteLike: (postId: string) =>
-    authRequest.delete("/likes/delete", { data: { id: postId } })
+  deleteLike: (likeId: string) =>
+    authRequest.delete("/likes/delete", { data: { id: likeId } })
 };
 
 export default likeAPI;

--- a/src/utils/apis/notification.ts
+++ b/src/utils/apis/notification.ts
@@ -3,7 +3,7 @@ import { ICreateNotification } from "../../types/apis";
 
 const notificationAPI = {
   getNotificationList: () => authRequest.get("/notifications"),
-  seenNotification: () => authRequest.get("/notifications/seen"),
+  seenNotification: () => authRequest.post("/notifications/seen"),
   createNotification: (payload: ICreateNotification) =>
     authRequest.post("/notifications/create", payload)
 };

--- a/src/utils/apis/post.ts
+++ b/src/utils/apis/post.ts
@@ -28,7 +28,12 @@ const postAPI = {
     authRequest.put("/posts/update", formData),
   deletePost: (postId: string) =>
     authRequest.delete("/posts/delete", { data: { id: postId } }),
-  allPost: () => unauthRequest.get("/posts")
+  allPost: ({ offset, limit }: IOffsetLimit = {}) => {
+    const hasParams = offset !== undefined && limit !== undefined;
+    return hasParams
+      ? unauthRequest.get("/posts", { params: { offset, limit } })
+      : unauthRequest.get("/posts");
+  }
 };
 
 export default postAPI;

--- a/src/utils/apis/post.ts
+++ b/src/utils/apis/post.ts
@@ -1,10 +1,26 @@
 import { unauthRequest, authRequest } from "./common";
+import { IOffsetLimit } from "src/types/apis";
 
 const postAPI = {
-  getChannelPostList: (channelId: string) =>
-    unauthRequest.get(`/posts/channel/${channelId}`),
-  getUserPostList: (authorId: string, payload) =>
-    unauthRequest.get(`/posts/author/${authorId}`, payload),
+  getChannelPostList: (
+    channelId: string,
+    { offset, limit }: IOffsetLimit = {}
+  ) => {
+    const hasParams = offset !== undefined && limit !== undefined;
+    return hasParams
+      ? unauthRequest.get(`/posts/channel/${channelId}`, {
+          params: { offset, limit }
+        })
+      : unauthRequest.get(`/posts/channel/${channelId}`);
+  },
+  getUserPostList: (authorId: string, { offset, limit }: IOffsetLimit = {}) => {
+    const hasParams = offset !== undefined && limit !== undefined;
+    return hasParams
+      ? unauthRequest.get(`/posts/author/${authorId}`, {
+          params: { offset, limit }
+        })
+      : unauthRequest.get(`/posts/author/${authorId}`);
+  },
   createPost: (formData: FormData) =>
     authRequest.post("/posts/create", formData),
   getPostDetail: (postId: string) => unauthRequest.get(`/posts/${postId}`),

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -1,7 +1,13 @@
 import { unauthRequest, authRequest } from "./common";
+import { IOffsetLimit } from "../../types/apis";
 
 const userAPI = {
-  getUserList: () => unauthRequest.get("/users/get-users"),
+  getUserList: ({ offset, limit }: IOffsetLimit = {}) => {
+    const hasParams = offset !== undefined && limit !== undefined;
+    return hasParams
+      ? unauthRequest.get("/users/get-users", { params: { offset, limit } })
+      : unauthRequest.get("/users/get-users");
+  },
   getOnlineUserList: () => unauthRequest.get("/users/online-users"),
   getUser: (id: string) => unauthRequest.get(`/users/${id}`),
   changeProfileImage: (formData: FormData) => {


### PR DESCRIPTION
# 개요
서버 통신 중 offset, limit 값을 필요로 하는 API 함수에서 해당 값을 Request parameter로 요청하도록 변경
# 작업 내용
## 변경된 API 메서드 목록
- userAPI
  - getUserList (사용자 목록을 불러옵니다.)
- postAPI
  - getChannelPostList (특정 채널의 포스트 목록을 불러옵니다.)
  - getUserPostList (특정 사용자의 포스트 목록을 불러옵니다.)
  - allPost (전체 포스트 목록을 불러옵니다.)

- offset, limit은 옵셔널 값이므로 기존 코드도 에러 없이 잘 동작합니다!
# 관련 이슈

# 사진
## offset, limit 사용 예시 코드
(offset=0번부터 limit=1개만 가져오도록!)
![image](https://user-images.githubusercontent.com/96400112/174474226-cc305e1e-aa68-4bd2-a42d-5f29e8dde106.png)

![offsetLimit](https://user-images.githubusercontent.com/96400112/174474235-99edaf1f-f34d-4167-996a-8ef6baed8ff2.gif)

## 뒤늦게 추가된 allPost
![image](https://user-images.githubusercontent.com/96400112/174481433-e7cf220e-95be-4ba0-a1bc-dec80adb1dcf.png)

![image](https://user-images.githubusercontent.com/96400112/174481426-459ec8bd-d6d5-4bd1-9f26-a6102d43b3cd.png)


## 추가 (06-20) GET 메서드가 아닌 PUT 메서드
- notificationAPI
  - seenNotification (나에게 온 알림을 읽음 처리합니다)
 
![image](https://user-images.githubusercontent.com/96400112/174488755-f030c882-aa4f-42dd-878e-32f815af3ae9.png)


<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #192 