### PR TITLE
✨ feat: DropDown 컴포넌트 추가

### DIFF
--- a/src/components/common/DropDown/DropDown.stories.tsx
+++ b/src/components/common/DropDown/DropDown.stories.tsx
@@ -1,0 +1,45 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { number } from "prop-types";
+import DropDown from "./DropDown";
+
+export default {
+  title: "component/DropDown",
+  component: DropDown,
+  argTypes: {
+    top: {
+      defaultValue: 50,
+      control: { action: number }
+    },
+    left: {
+      defaultValue: 0,
+      control: { action: number }
+    }
+  }
+} as ComponentMeta<typeof DropDown>;
+
+export const Default: ComponentStory<typeof DropDown> = (args) => {
+  const event = (num) => {
+    alert(num + "클릭");
+  };
+
+  const contents = [
+    {
+      label: "닉네임변경",
+      event: () => event(1)
+    },
+    {
+      label: "비밀번호 변경",
+      event: () => event(2)
+    },
+    {
+      label: "프로필 변경",
+      event: () => event(3)
+    }
+  ];
+
+  return (
+    <DropDown contents={contents} {...args}>
+      <button>드롭다운</button>
+    </DropDown>
+  );
+};

--- a/src/components/common/DropDown/DropDown.tsx
+++ b/src/components/common/DropDown/DropDown.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+import * as S from "./style";
+
+type content = {
+  label: string;
+  event: () => void;
+};
+interface DropDownInterface {
+  children: React.ReactNode;
+  contents: content[];
+  top?: number;
+  left?: number;
+}
+
+const DropDown: React.FC<DropDownInterface> = ({
+  children,
+  contents,
+  top = 50,
+  left = 0
+}) => {
+  const [showDropDown, setShowDropDown] = useState<boolean>(false);
+
+  return (
+    <S.DropDown>
+      <S.DropDownBtn onClick={() => setShowDropDown(!showDropDown)}>
+        {children}
+      </S.DropDownBtn>
+      <S.DropBox showDropDown={showDropDown} top={top} left={left}>
+        {contents.map((item, i) => (
+          <button key={i} onClick={item.event}>
+            {item.label}
+          </button>
+        ))}
+      </S.DropBox>
+    </S.DropDown>
+  );
+};
+
+export default DropDown;

--- a/src/components/common/DropDown/index.tsx
+++ b/src/components/common/DropDown/index.tsx
@@ -1,0 +1,3 @@
+import DropDown from "./DropDown";
+
+export default DropDown;

--- a/src/components/common/DropDown/style.tsx
+++ b/src/components/common/DropDown/style.tsx
@@ -1,0 +1,41 @@
+import styled from "@emotion/styled";
+import theme from "src/styles/theme";
+
+export const DropDown = styled.div`
+  position: relative;
+`;
+export const DropDownBtn = styled.div`
+  display: inline;
+`;
+
+export const DropBox = styled.div<{
+  showDropDown: boolean;
+  top: number;
+  left: number;
+}>`
+  position: absolute;
+  top: ${({ top }) => top}px;
+  left: ${({ left }) => left}px;
+  display: inline-flex;
+  padding: 5px 0;
+  flex-direction: column;
+  border-radius: 8px;
+  color: #fff;
+  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  z-index: 50;
+  transition: all 0.3s;
+  visibility: ${({ showDropDown }) => (showDropDown ? "visible" : "hidden")};
+  opacity: ${({ showDropDown }) => (showDropDown ? 1 : 0)};
+  button {
+    padding: 10px 15px;
+    border: none;
+    background-color: #fff;
+    transition: all 0.4s;
+    font-weight: bold;
+    cursor: pointer;
+    :hover {
+      color: ${theme.$gray600};
+    }
+  }
+`;


### PR DESCRIPTION
# 개요
DropDown 컴포넌트 추가

# 작업 내용

### 사용법
- props로 top, left를 num으로 받아 DropDown위치 지정가능
- 내부 컨텐츠 내용과 함수는 아래 배열 모양으로 넘겨준다.
```
 const contents = [
    {
      label: "닉네임변경",
      event: () => event(1)
    },
    {
      label: "비밀번호 변경",
      event: () => event(2)
    },
    {
      label: "프로필 변경",
      event: () => event(3)
    }
  ];
```
```js
<DropDown contents={contents}>
    <button>드롭다운</button>
  </DropDown>
```
- children과 contents만 필수값이다.
- top: 50px, left: 0px 이 기본값이다.

# 관련 이슈
closes #181

# 사진
![녹화_2022_06_19_19_29_48_356](https://user-images.githubusercontent.com/87519250/174476669-d4ee182f-7959-43ba-8366-2e57d7738353.gif)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
