### PR TITLE
✨ feat: 상세 페이지 서버통신 구현

### DIFF
--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -42,7 +42,7 @@ const Textarea: React.FC<TextareaInterface> = ({
       isIntroduction={isIntroduction}
       disabled={!isLogin}
       placeholder={placeholderText}
-      onChange={isIntroduction ? onChange : null}
+      onChange={children !== null ? onChange : null}
       onInput={isIntroduction ? handleResizeHeight : null}
       ref={isIntroduction ? ref : null}
     >

--- a/src/components/common/Textarea/style.tsx
+++ b/src/components/common/Textarea/style.tsx
@@ -9,9 +9,12 @@ export const Textarea = styled.textarea<{
 
   height: ${({ isIntroduction }) => (isIntroduction ? "400" : "80")}px;
 
+  border-color: #40a9ff;
+  outline-color: #096dd9;
+  box-shadow: rgba(24, 144, 255, 0.2);
   border-radius: ${({ isIntroduction }) => (isIntroduction ? "0" : "10")}px;
-
   padding: 10px;
+  line-height: 150%;
   @media (max-width: 700px) {
     padding: 0 18px;
     box-sizing: border-box;

--- a/src/components/detail/PostBody/PostBody.tsx
+++ b/src/components/detail/PostBody/PostBody.tsx
@@ -1,26 +1,31 @@
 import * as S from "./style";
 import Button from "../../common/Button";
 import theme from "../../../styles/theme";
-
 interface PostBodyInterface {
   introduction: string;
+  postEdit: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-const PostBody: React.FC<PostBodyInterface> = ({ introduction }) => {
+const PostBody: React.FC<PostBodyInterface> = ({ introduction, postEdit }) => {
+  const isAuthor = true; // 추후 Context API로 구현
   return (
     <S.PostBody>
       {/* 추후 global font로 교체 예정 */}
       <S.Section>프로젝트 소개</S.Section>
       <hr color={theme.$yellow} />
       <S.IntroductionDiv>{introduction}</S.IntroductionDiv>
-      <S.Wrapper>
-        <Button buttonType="gray-line" width="100">
-          수정
-        </Button>
-        <Button buttonType="gray-line" width="100">
-          삭제
-        </Button>
-      </S.Wrapper>
+      {isAuthor ? (
+        <S.Wrapper>
+          <Button buttonType="gray-line" width="100" onClick={postEdit}>
+            수정
+          </Button>
+          <Button buttonType="gray-line" width="100">
+            삭제
+          </Button>
+        </S.Wrapper>
+      ) : (
+        <S.Wrapper></S.Wrapper>
+      )}
     </S.PostBody>
   );
 };

--- a/src/components/detail/PostFooter/Comment/Comment.tsx
+++ b/src/components/detail/PostFooter/Comment/Comment.tsx
@@ -1,23 +1,23 @@
 import * as S from "./style";
 import ProfileImage from "../../../common/ProfileImage";
 import theme from "../../../../styles/theme";
-
+import { useState } from "react";
 interface CommentInterface {
+  key: string;
+  commentId: string;
   comment: string;
+  comments: object[];
   author: string;
   updatedAt: string;
+  deleteComment: (value: object, id: string) => void;
 }
 
-const deleteComment = () => {
-  if (window.confirm("댓글을 삭제하시겠습니까?")) {
-    alert("삭제 구현중!!");
-  }
-};
-
 const Comment: React.FC<CommentInterface> = ({
+  commentId,
   comment,
   author,
-  updatedAt
+  updatedAt,
+  deleteComment
 }) => {
   return (
     <div>
@@ -32,7 +32,7 @@ const Comment: React.FC<CommentInterface> = ({
       <S.DeleteCommetDiv>
         <span></span>
         <span
-          onClick={deleteComment}
+          onClick={(e) => deleteComment(e, commentId)}
           style={{ textDecoration: "underline", color: theme.$gray600 }}
         >
           댓글삭제

--- a/src/components/detail/PostFooter/PostFooter.tsx
+++ b/src/components/detail/PostFooter/PostFooter.tsx
@@ -1,27 +1,34 @@
 import * as S from "./style";
 import TextareaBox from "./TextareaBox";
 import Comment from "./Comment";
+import { useEffect, useState } from "react";
 
 interface PostFooterInterface {
   comments: object[];
+  postId: string;
+  setComments: (value: object) => void;
+  deleteComment: (value: object, id: string) => void;
 }
 
-const PostFooter: React.FC<PostFooterInterface> = ({ comments }) => {
+const PostFooter: React.FC<PostFooterInterface> = ({
+  comments,
+  postId,
+  setComments,
+  deleteComment
+}) => {
   let paramComment;
   let paramAuthor;
   let paramUpdatedAt;
   let paramKey;
-  /* for (let i = 0; i < comments.length; i += 1) {
-    let prop;
-    for (prop in comments[i]) {
-      if (Object.prototype.hasOwnProperty.call(comments[i], prop)) {
-        console.log(comments[i][prop]);
-      }
-    }
-  } */
+
   return (
     <S.PostFooter>
-      <TextareaBox length={comments.length}></TextareaBox>
+      <TextareaBox
+        length={comments.length}
+        postId={postId}
+        comments={comments}
+        setComments={setComments}
+      ></TextareaBox>
       <div>
         {comments.map((comment) => {
           let prop;
@@ -32,10 +39,12 @@ const PostFooter: React.FC<PostFooterInterface> = ({ comments }) => {
                   paramComment = comment[prop];
                   break;
                 case "author":
-                  paramAuthor = comment[prop];
+                  paramAuthor = comment[prop].fullName;
                   break;
                 case "updatedAt":
-                  paramUpdatedAt = comment[prop];
+                  paramUpdatedAt = comment[prop]
+                    .substring(0, 10)
+                    .replaceAll("-", ".");
                   break;
                 case "_id":
                   paramKey = comment[prop];
@@ -47,10 +56,13 @@ const PostFooter: React.FC<PostFooterInterface> = ({ comments }) => {
           }
           return (
             <Comment
+              key={paramKey}
+              commentId={paramKey}
               comment={paramComment}
               author={paramAuthor}
               updatedAt={paramUpdatedAt}
-              key={paramKey}
+              deleteComment={deleteComment}
+              comments={comments}
             />
           );
         })}

--- a/src/components/detail/PostFooter/TextareaBox/TextareaBox.tsx
+++ b/src/components/detail/PostFooter/TextareaBox/TextareaBox.tsx
@@ -1,17 +1,78 @@
 import * as S from "./style";
 import Button from "../../../common/Button";
 import Textarea from "../../../common/Textarea";
-
+import commentAPI from "../../../../utils/apis/comment";
+import { useState } from "react";
+import { render } from "@testing-library/react";
 interface TextareaBoxInterface {
   length: number;
+  postId: string;
+  comments: object[];
+  setComments: (value: object) => void;
 }
 
-const TextareaBox: React.FC<TextareaBoxInterface> = ({ length }) => {
+const TextareaBox: React.FC<TextareaBoxInterface> = ({
+  length,
+  postId,
+  comments,
+  setComments
+}) => {
+  const isLoggedIn = true; // 추후 Context API로 변경
+  const [commentText, setCommentText] = useState("");
+  const onCommentChange = (event) => {
+    setCommentText(event.currentTarget.value);
+  };
+
+  const createComment = async (event) => {
+    if (confirm("댓글을 등록하시겠습니까?")) {
+      try {
+        await commentAPI.createComment({
+          comment: commentText,
+          postId: postId
+        });
+        setCommentText(() => "");
+        setComments((comments) => [
+          ...comments,
+          {
+            comment: commentText,
+            post: postId
+          }
+        ]);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  };
+
   return (
     <div>
       <S.Section>{length}개의 댓글이 있습니다.</S.Section>
       <hr color="#FFD613" />
-      <S.Textarea>
+      {isLoggedIn ? (
+        <div>
+          <S.Textarea>
+            <Textarea
+              isIntroduction={false}
+              isLogin={true}
+              onChange={onCommentChange}
+            ></Textarea>
+          </S.Textarea>
+          <S.SubmitDiv>
+            <div></div>
+            <Button
+              buttonType="blue"
+              isRound={true}
+              width="200"
+              onClick={createComment}
+            >
+              댓글 등록
+            </Button>
+          </S.SubmitDiv>
+        </div>
+      ) : (
+        <div></div>
+      )}
+      {/* <S.Textarea>
         <Textarea isIntroduction={false} isLogin={true}></Textarea>
       </S.Textarea>
       <S.SubmitDiv>
@@ -19,7 +80,7 @@ const TextareaBox: React.FC<TextareaBoxInterface> = ({ length }) => {
         <Button buttonType="blue" isRound={true} width="200">
           댓글 등록
         </Button>
-      </S.SubmitDiv>
+      </S.SubmitDiv> */}
     </div>
   );
 };

--- a/src/components/detail/PostHeader/PostHeader.tsx
+++ b/src/components/detail/PostHeader/PostHeader.tsx
@@ -12,10 +12,12 @@ interface PostHeaderInterface {
   authorId: string;
   createdAt: string;
   channel: string;
+  people: string;
   email: string;
   place: string;
   startDate: string;
   expectedDate: string;
+  skills: [];
 }
 
 const PostHeader: React.FC<PostHeaderInterface> = ({
@@ -23,10 +25,12 @@ const PostHeader: React.FC<PostHeaderInterface> = ({
   authorId,
   createdAt,
   channel,
+  people,
   email,
   place,
   startDate,
-  expectedDate
+  expectedDate,
+  skills
 }) => {
   return (
     <>
@@ -51,10 +55,12 @@ const PostHeader: React.FC<PostHeaderInterface> = ({
       <S.PostSection>요약</S.PostSection>
       <PostSummary
         channel={channel}
+        people={people}
         email={email}
         place={place}
         startDate={startDate}
         expectedDate={expectedDate}
+        skills={skills}
       ></PostSummary>
     </>
   );

--- a/src/components/detail/PostHeader/PostSummary/PostSummary.tsx
+++ b/src/components/detail/PostHeader/PostSummary/PostSummary.tsx
@@ -4,6 +4,7 @@ interface PostSummaryInterface {
   channel: string;
   email: string;
   place: string;
+  people: string;
   startDate: string;
   expectedDate: string;
   [skills: string]: any;
@@ -13,6 +14,7 @@ const PostSummary: React.FC<PostSummaryInterface> = ({
   channel,
   email,
   place,
+  people,
   startDate,
   expectedDate,
   skills
@@ -26,6 +28,10 @@ const PostSummary: React.FC<PostSummaryInterface> = ({
       <tr>
         <td>모집분야</td>
         <td>{channel}</td>
+      </tr>
+      <tr>
+        <td>모집인원</td>
+        <td>{people}</td>
       </tr>
       <tr>
         <td>연락 방법</td>
@@ -48,9 +54,10 @@ const PostSummary: React.FC<PostSummaryInterface> = ({
         {/* <td>{skills}</td> */}
         <td>
           <S.FlexBetween>
-            <SkillIcon name="type_script" alt="TypeScript" />
-            <SkillIcon name="react" alt="React" />
-            <SkillIcon name="redux" alt="Redux" />
+            {skills &&
+              skills.map((skill) => {
+                return <SkillIcon key="" name={skill.toString()} alt={skill} />;
+              })}
           </S.FlexBetween>
         </td>
       </tr>


### PR DESCRIPTION
# 개요
작업량이 많아져서 PR을 나누고 중간병합을 하려합니다.

# 작업 내용
- Textarea 스타일 수정
- 댓글 등록 및 삭제 서버통신 구현
- 게시글 상세 보기 서버통신 구현

# 관련 이슈
- 계정에 따라 보여줘야되는 요소 분기처리 작업 필요
- 댓글을 등록한 후에 바로 삭제하면 페이지에서 바로 반영이 되지 않아요. 이 부분은 다음 PR때 반영하려합니다.
- 수정 페이지로 넘기는 Navigate 부분도 다음 PR때 반영하겠습니다.
- 상세 페이지 상단의 화살표 아이콘과 좋아요 기능도 구현해야됩니다.(이건 금방 할 수 있을거같아요!)

# 사진
- 프로젝트 소개글
![image](https://user-images.githubusercontent.com/15838144/174493958-28f7d511-f682-4082-a22e-ec7e90902479.png)

- 댓글 작성 기능

https://user-images.githubusercontent.com/15838144/174494133-23be176b-37df-478b-845d-e581572eeabb.mov


- 댓글 삭제 기능

https://user-images.githubusercontent.com/15838144/174494156-08370c80-0156-487a-98e2-39ff00009286.mov

closes #174 