### PR TITLE
🐛 fix: 로그인 페이지 에러 형식 확인 후 API 요청으로 수정

### DIFF
--- a/src/hooks/useSignIn.tsx
+++ b/src/hooks/useSignIn.tsx
@@ -43,6 +43,7 @@ const useSignIn = ({ initialValues, isError }) => {
           if (err.response.status === 400) {
             alert("이메일 또는 비밀번호를 확인해주세요");
             setValues({ email: "", password: "" });
+            setErrors({});
           }
         });
       setIsLoading(false);

--- a/src/hooks/useSignIn.tsx
+++ b/src/hooks/useSignIn.tsx
@@ -21,31 +21,32 @@ const useSignIn = ({ initialValues, isError }) => {
   };
 
   const handleSubmit = async (e) => {
-    setIsLoading(true);
     e.preventDefault();
-    await authAPI
-      .signIn({
-        email: values.email,
-        password: values.password
-      })
-      .then((res) => {
-        const { user, token } = res.data;
-        onLogin(user);
-        storage.setItem("TOKEN", token);
-        navigate("/");
-      })
-      .catch((err) => {
-        if (err.response.status === 400) {
-          const newErrors = isError ? isError(values) : {};
-          if (Object.keys(newErrors).length !== 0) {
-            setErrors(newErrors);
-          } else {
+    setIsLoading(true);
+    const newErrors = isError(values);
+
+    if (Object.keys(newErrors).length !== 0) {
+      setErrors(newErrors);
+    } else {
+      await authAPI
+        .signIn({
+          email: values.email,
+          password: values.password
+        })
+        .then((res) => {
+          const { user, token } = res.data;
+          onLogin(user);
+          storage.setItem("TOKEN", token);
+          navigate("/");
+        })
+        .catch((err) => {
+          if (err.response.status === 400) {
             alert("이메일 또는 비밀번호를 확인해주세요");
             setValues({ email: "", password: "" });
           }
-        }
-      });
-    setIsLoading(false);
+        });
+      setIsLoading(false);
+    }
   };
 
   return {

--- a/src/pages/signIn/signIn.tsx
+++ b/src/pages/signIn/signIn.tsx
@@ -56,7 +56,7 @@ const SignIn: React.FC = () => {
           />
         </S.MarginWrapper>
         <S.MarginWrapper>
-          <Button onClick={handleSubmit}>로그인</Button>
+          <Button onClick={handleSubmit}>Login</Button>
         </S.MarginWrapper>
         <S.CheckId>
           <span>회원이 아니신가요?</span>

--- a/src/pages/signIn/signIn.tsx
+++ b/src/pages/signIn/signIn.tsx
@@ -22,10 +22,9 @@ const SignIn: React.FC = () => {
         errors.email = "올바른 이메일 형식이 아닙니다 ";
 
       if (!password) errors.password = "비밀번호를 입력해주세요";
-      else if (!/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]$/.test(password))
-        errors.password = "비밀번호는 하나 이상의 문자와 숫자여야 합니다";
-      else if (password.length < 6 || password.length > 12)
-        errors.password = "비밀번호는 6자리 이상 12자리 이하여야 합니다";
+      else if (!/^(?=.*[a-zA-Z])(?=.*[0-9]).{6,12}$/.test(password))
+        errors.password =
+          "비밀번호는 숫자, 문자로 이루어진 6~12자리여야 합니다";
       return errors;
     }
   });

--- a/src/pages/signIn/signIn.tsx
+++ b/src/pages/signIn/signIn.tsx
@@ -24,7 +24,7 @@ const SignIn: React.FC = () => {
       if (!password) errors.password = "비밀번호를 입력해주세요";
       else if (!/^(?=.*[a-zA-Z])(?=.*[0-9]).{6,12}$/.test(password))
         errors.password =
-          "비밀번호는 숫자, 문자로 이루어진 6~12자리여야 합니다";
+          "비밀번호는 숫자, 영문자로 이루어진 6~12자리여야 합니다";
       return errors;
     }
   });
@@ -41,6 +41,7 @@ const SignIn: React.FC = () => {
             label="이메일"
             name="email"
             value={values.email}
+            placeholder="이메일을 입력해주세요"
             onChange={handleChange}
             errorMessage={errors.email}
           />
@@ -51,6 +52,7 @@ const SignIn: React.FC = () => {
             name="password"
             type="password"
             value={values.password}
+            placeholder="비밀번호를 입력해주세요"
             onChange={handleChange}
             errorMessage={errors.password}
           />

--- a/src/pages/signIn/style.tsx
+++ b/src/pages/signIn/style.tsx
@@ -6,7 +6,7 @@ export const LogInWrapper = styled.div`
 
 export const Image = styled.div`
   text-align: center;
-  margin: 40px 0;
+  padding: 40px 0;
   cursor: pointer;
 `;
 

--- a/src/pages/signIn/style.tsx
+++ b/src/pages/signIn/style.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 export const LogInWrapper = styled.div`
-  margin: 20px 25%;
+  margin: 0 25%;
 `;
 
 export const Image = styled.div`


### PR DESCRIPTION
# 개요
로그인 페이지 API 통신 조건 수정

# 작업 내용
로그인 submit 시 
API 통신 에러가 발견하면 에러 메세지를 설정하는 방식 -> 에러 메세지가 아닌 경우에만 유효한 계정인지 API 통신을 하는 방법으로 변경했습니다
thanks to @YuHyun-P 
# 이슈
close #206 

# 사진
![login_error](https://user-images.githubusercontent.com/95457808/174497597-27ec72b2-547d-437d-a1b2-5659c41a0580.gif)

