### PR TITLE
✨ feat: EditPassword 컴포넌트 구현

### DIFF
--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -4,7 +4,7 @@ interface InputInterface {
   type?: string;
   width?: number;
   placeholder?: string;
-  value: string;
+  value?: string;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   name?: string;
 }

--- a/src/components/profile/EditPassword/EditPassword.tsx
+++ b/src/components/profile/EditPassword/EditPassword.tsx
@@ -1,0 +1,69 @@
+import { FC, Fragment } from "react";
+import useEditForm from "@hooks/useEditForm";
+import { settingAPI } from "@utils/apis";
+import { Button } from "@components/common";
+import InputBox from "@components/create/InputBox/InputBox";
+import * as S from "./style";
+
+export const passwordRegExp = /^(?=.*[a-zA-Z])(?=.*[0-9]).{6,12}$/;
+
+type Values = {
+  password: string;
+  passwordConfirm: string;
+};
+
+const EditPassword: FC = () => {
+  const { isLoading, errors, handleChange, handleSubmit } = useEditForm<Values>(
+    {
+      initialValue: {
+        password: "",
+        passwordConfirm: ""
+      },
+      onSubmit: (values: Values) => settingAPI.changePwd(values.password),
+      validate: ({ password, passwordConfirm }) => {
+        const errors = {};
+
+        if (password === "") {
+          errors["password"] = "비밀번호를 입력해주세요";
+        } else if (!passwordRegExp.test(password)) {
+          errors["password"] =
+            "비밀번호는 숫자, 영문자로 이루어진 6~12자리여야 합니다";
+        } else if (password !== passwordConfirm) {
+          errors["passwordConfirm"] = "비밀번호가 일치하지 않습니다";
+        }
+
+        return errors;
+      }
+    }
+  );
+
+  return (
+    <Fragment>
+      <form action="" onSubmit={handleSubmit}>
+        <S.Strong>비밀번호 변경</S.Strong>
+
+        <S.FlexContainer>
+          <InputBox
+            name="password"
+            label="새 비밀번호"
+            errorMessage={errors["password"]}
+            onChange={handleChange}
+          />
+
+          <InputBox
+            name="passwordConfirm"
+            label="새 비밀번호 확인"
+            errorMessage={errors["passwordConfirm"]}
+            onChange={handleChange}
+          />
+        </S.FlexContainer>
+
+        <S.ButtonWrapper>
+          <Button>변경하기</Button>
+        </S.ButtonWrapper>
+      </form>
+    </Fragment>
+  );
+};
+
+export default EditPassword;

--- a/src/components/profile/EditPassword/index.tsx
+++ b/src/components/profile/EditPassword/index.tsx
@@ -1,0 +1,3 @@
+import EditPassword from "./EditPassword";
+
+export default EditPassword;

--- a/src/components/profile/EditPassword/style.tsx
+++ b/src/components/profile/EditPassword/style.tsx
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+
+export const Strong = styled.strong`
+  display: block;
+  font-weight: 700;
+  font-size: 21px;
+  margin-bottom: 31px;
+`;
+
+export const FlexContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+
+  label {
+    line-height: 22px;
+    margin: 0 0 4px;
+  }
+`;
+
+export const ButtonWrapper = styled.div`
+  margin-top: 34px;
+`;

--- a/src/components/profile/Modal/index.tsx
+++ b/src/components/profile/Modal/index.tsx
@@ -24,7 +24,6 @@ export const Modal: React.FC<ModalInterface> = ({
 
   const el = useMemo(() => document.createElement("div"), []);
   useEffect(() => {
-    el.style.height = "100%";
     document.body.appendChild(el);
     return () => {
       document.body.removeChild(el);

--- a/src/components/profile/index.tsx
+++ b/src/components/profile/index.tsx
@@ -4,5 +4,14 @@ import Modal from "./Modal";
 import Tab from "./Tab";
 import ProfileImageBox from "./ProfileImageBox";
 import EditFullName from "./EditFullName";
+import EditPassword from "./EditPassword";
 
-export { CoverImage, CoverImageBox, Modal, ProfileImageBox, Tab, EditFullName };
+export {
+  CoverImage,
+  CoverImageBox,
+  Modal,
+  ProfileImageBox,
+  Tab,
+  EditFullName,
+  EditPassword
+};

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -2,3 +2,4 @@ export { default as useAxios } from "./useAxios";
 export { default as useAxiosFn } from "./useAxiosFn";
 export { default as useClickAway } from "./useClickAway";
 export { default as useHover } from "./useHover";
+export { default as useEditForm } from "./useEditForm";

--- a/src/hooks/useEditForm.ts
+++ b/src/hooks/useEditForm.ts
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { AxiosResponse } from "axios";
+
+type EditForm<T> = {
+  initialValue: T;
+  onSubmit: (args: T) => Promise<AxiosResponse>;
+  validate?: (values: T) => object;
+};
+
+const useEditForm = <T>({ initialValue, onSubmit, validate }: EditForm<T>) => {
+  const [values, setValues] = useState<T>(initialValue);
+  const [errors, setErrors] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setValues({ ...values, [name]: value });
+    setErrors({});
+  };
+
+  const handleSubmit = async (e) => {
+    setIsLoading(true);
+    e.preventDefault();
+
+    const newErrors = validate ? validate(values) : {};
+    if (Object.keys(newErrors).length === 0) {
+      await onSubmit(values);
+    }
+    setErrors(newErrors);
+
+    setIsLoading(false);
+  };
+
+  return {
+    values,
+    errors,
+    isLoading,
+    handleChange,
+    handleSubmit
+  };
+};
+
+export default useEditForm;

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -9,6 +9,7 @@ import {
   ProfileImageBox,
   CoverImageBox,
   EditFullName,
+  EditPassword,
   Modal
 } from "@components/profile";
 import * as S from "./style";
@@ -19,7 +20,8 @@ const Profile: React.FC = () => {
   const user = DUMMY_USER;
 
   const [isMine, setIsMine] = useState(false);
-  const [visible, setVisible] = useState(false);
+  const [editFullNameVisible, setEditFullNameVisible] = useState(false);
+  const [editPasswordVisible, setEditPasswordVisible] = useState(false);
 
   return (
     <>
@@ -102,13 +104,25 @@ const Profile: React.FC = () => {
 
         <Modal
           height="294px"
-          visible={visible}
-          onClose={() => setVisible(false)}
+          visible={editFullNameVisible}
+          onClose={() => setEditFullNameVisible(false)}
         >
           <EditFullName />
         </Modal>
+        <button onClick={() => setEditFullNameVisible(true)}>
+          닉네임 변경 모달 얍
+        </button>
 
-        <button onClick={() => setVisible(true)}>모달 얍</button>
+        <Modal
+          height="384px"
+          visible={editPasswordVisible}
+          onClose={() => setEditPasswordVisible(false)}
+        >
+          <EditPassword />
+        </Modal>
+        <button onClick={() => setEditPasswordVisible(true)}>
+          비밀번호 변경 모달 얍
+        </button>
       </S.Layout>
 
       <Footer />


### PR DESCRIPTION
# 개요
프로필 페이지에 비밀번호 변경 모달에 사용할 EditPassword 컴포넌트 구현
# 작업 내용
- 서버 통신 연결 O
- 비밀번호 검증  O (6-12자 숫자, 영문자 조합)
- useEditForm 훅 구현
  - Input 컴포넌트의 props.value 를 옵셔널로 변경해야 해당 훅을 사용할 수 있어 수정했습니다.
# 관련 이슈
- 변경된 후 처리가 완료되었음을 어떻게 알릴 지 고민입니다..(모달 창 닫기? alert로 알리기? 흠🙄)
- context API와 연결하지 않았습니다
- useEditForm 훅을 구현해서 EditFullName 컴포넌트도 해당 훅을 사용하도록 리팩토링 할 예정입니다.

# 사진
![비밀번호 변경 ](https://user-images.githubusercontent.com/96400112/174498653-f3a4759c-ba43-4e19-a423-f9a3cffc8235.gif)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #196 