### PR TITLE
✨ feat: 수정페이지 navigate 구현

### DIFF
--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -6,16 +6,17 @@ interface TextareaInterface {
   isIntroduction: boolean;
   children?: React.ReactNode;
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  textAreaRef?: React.MutableRefObject<HTMLTextAreaElement>;
 }
 
 const Textarea: React.FC<TextareaInterface> = ({
   isLogin,
   isIntroduction,
   children,
-  onChange
+  onChange,
+  textAreaRef
 }) => {
   const ref = useRef<HTMLTextAreaElement>(null);
-  const [ContentValue, setContentValue] = useState(""); // 수정 페이지에서 불러올 value관리
 
   const handleResizeHeight = useCallback(() => {
     if (
@@ -44,7 +45,7 @@ const Textarea: React.FC<TextareaInterface> = ({
       placeholder={placeholderText}
       onChange={children !== null ? onChange : null}
       onInput={isIntroduction ? handleResizeHeight : null}
-      ref={isIntroduction ? ref : null}
+      ref={textAreaRef}
     >
       {children}
     </S.Textarea>

--- a/src/components/detail/PostFooter/TextareaBox/TextareaBox.tsx
+++ b/src/components/detail/PostFooter/TextareaBox/TextareaBox.tsx
@@ -2,8 +2,7 @@ import * as S from "./style";
 import Button from "../../../common/Button";
 import Textarea from "../../../common/Textarea";
 import commentAPI from "../../../../utils/apis/comment";
-import { useState } from "react";
-import { render } from "@testing-library/react";
+import { useState, useRef } from "react";
 interface TextareaBoxInterface {
   length: number;
   postId: string;
@@ -19,11 +18,16 @@ const TextareaBox: React.FC<TextareaBoxInterface> = ({
 }) => {
   const isLoggedIn = true; // 추후 Context API로 변경
   const [commentText, setCommentText] = useState("");
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const onCommentChange = (event) => {
     setCommentText(event.currentTarget.value);
   };
 
   const createComment = async (event) => {
+    if (commentText.length === 0) {
+      textAreaRef.current.focus();
+      return;
+    }
     if (confirm("댓글을 등록하시겠습니까?")) {
       try {
         await commentAPI.createComment({
@@ -55,6 +59,7 @@ const TextareaBox: React.FC<TextareaBoxInterface> = ({
               isIntroduction={false}
               isLogin={true}
               onChange={onCommentChange}
+              textAreaRef={textAreaRef}
             ></Textarea>
           </S.Textarea>
           <S.SubmitDiv>

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -23,7 +23,7 @@ const Detail: React.FC = () => {
   let paramChannel;
   let paramSkills;
   let paramPeople;
-
+  let editParamChannel;
   const getPostDetail = async (id) => {
     try {
       const { data } = await postAPI.getPostDetail(id);
@@ -43,20 +43,24 @@ const Detail: React.FC = () => {
         setComments(comments.filter((comment) => comment._id !== id));
       } catch (error) {
         console.error(error);
-        console.log(error);
       }
     }
   };
 
   const editHandler = () => {
-    editNavigate("/edit/" + `${postId}`, {
+    editNavigate("/edit/" + `${titleObj[prop].channel}` + "/" + `${postId}`, {
       state: {
-        title: paramTitle,
-        place: paramPlace,
-        email: paramEmail,
-        startDate: paramStartDate,
-        expectedDate: paramExpectedDate,
-        introduction: paramIntroduction
+        postId: postId != null ? postId : "",
+        title: paramTitle != null ? paramTitle : "",
+        place: paramPlace != null ? paramPlace : "",
+        email: paramEmail != null ? paramEmail : "",
+        startDate: paramStartDate != null ? paramStartDate : "",
+        expectedDate: paramExpectedDate != null ? paramExpectedDate : "",
+        channel: editParamChannel != null ? editParamChannel : "",
+        people: paramPeople != null ? paramPeople : "",
+        skills: paramSkills != null ? paramSkills : "",
+        introduction: paramIntroduction != null ? paramIntroduction : "",
+        image: postDetail.image != null ? postDetail.image : ""
       }
     });
   };
@@ -66,6 +70,7 @@ const Detail: React.FC = () => {
   }, []);
 
   const getChannel = (channel) => {
+    editParamChannel = channel;
     switch (channel) {
       case "front":
         return "프론트엔드";
@@ -169,38 +174,6 @@ const DUMMY_DETAIL = {
       post: "62a62988c882bf3a287f9c8a", // 포스트 id
       createdAt: "2022.06.14",
       updatedAt: "2022.06.14"
-    },
-    {
-      _id: "2",
-      comment: `안녕하세요 개인적으로 프로젝트에 궁금한 점이 있어서 질문남겨요. 
-        혹시 프로젝트는 어떤 기획은 정해져 있나요? 어떤 주제로 할 생각이신가요? 
-        디자이너는 따로 구하는 글이 없던데 이미 모집되어 있으신지요안녕하세요 개인적으로 프로젝트에 궁금한 점이 있어서 질문남겨요. 
-        혹시 프로젝트는 어떤 기획은 정해져 있나요? 어떤 주제로 할 생각이신가요? 
-        디자이너는 따로 구하는 글이 없던데 이미 모집되어 있으신지요안녕하세요 
-        개인적으로 프로젝트에 궁금한 점이 있어서 질문남겨요. 혹시 프로젝트는 어떤 기획은 정해져 있나요? 
-        어떤 주제로 할 생각이신가요? 디자이너는 따로 구하는 글이 없던데 이미 모집되어 있으신지요`,
-      author: "마혜경",
-      post: "62a62988c882bf3a287f9c8a", // 포스트 id
-      createdAt: "2022.06.15",
-      updatedAt: "2022.06.15"
-    },
-    {
-      _id: "3",
-      comment: `프로젝트 기간안에 다 할 수 있을까요?? ㅠㅠ`,
-      author: "박유현",
-      post: "62a62988c882bf3a287f9c8a", // 포스트 id
-      createdAt: "2022.06.15",
-      updatedAt: "2022.06.15"
-    },
-    {
-      _id: "4",
-      comment: `안녕하세요 개인적으로 프로젝트에 궁금한 점이 있어서 질문남겨요. 
-        혹시 프로젝트는 어떤 기획은 정해져 있나요? 어떤 주제로 할 생각이신가요? 
-        디자이너는 따로 구하는 글이 없던데 이미 모집되어 있으신지요`,
-      author: "정현진",
-      post: "62a62988c882bf3a287f9c8a", // 포스트 id
-      createdAt: "2022.06.15",
-      updatedAt: "2022.06.15"
     }
   ],
   _id: "62a62988c882bf3a287f9c8a",
@@ -249,5 +222,6 @@ const DUMMY_DETAIL = {
   },
   createdAt: "2022-06-12T17:59:36.277Z",
   updatedAt: "2022-06-12T18:02:42.434Z",
-  __v: 0
+  __v: 0,
+  image: ""
 };

--- a/src/pages/detail/index.tsx
+++ b/src/pages/detail/index.tsx
@@ -1,0 +1,2 @@
+import Detail from "./detail";
+export default Detail;


### PR DESCRIPTION
# 개요
수정페이지 navigate 구현

# 작업 내용
- 상세페이지 -> 수정페이지 navigate 구현

|변수명|용어|
|-|-|
|postId|게시글 ID|
|title|제목|
|place|진행 방식|
|email|연락 방법|
|startDate|시작일|
|expectedDate|예상 기간|
|channel|모집분야|
|people|모집인원|
|skills|기술스택|
|introduction|소개글|
|images|이미지 정보|
- Textarea useRef prop 추가

# 관련 이슈
- 이미지 정보는 아직 api 서버쪽에 데이터가 없어서 제대로 테스트가 안됐습니다. 
(생성페이지에서 이미지가 있는 게시글 생성 시 데이터 확인 필요)

# 사진
- location log
![image](https://user-images.githubusercontent.com/15838144/174501824-ecd3c0ba-b753-4dda-b49c-2a33b13ac997.png)

- Textarea focus

https://user-images.githubusercontent.com/15838144/174501860-8b2d6060-a2a6-46dd-a994-51a21d481f09.mov

closes #209 
