### PR TITLE
✨ feat: 회원 가입 페이지 구현

### DIFF
--- a/src/components/signUp/index.tsx
+++ b/src/components/signUp/index.tsx
@@ -1,1 +1,5 @@
-export {};
+import Button from "../common/Button";
+import InputBox from "../create/InputBox/InputBox";
+import AppLayout from "../common/AppLayout/AppLayout";
+import logoImg from "../../assets/logos/logo_favicon.svg";
+export { InputBox, Button, AppLayout, logoImg };

--- a/src/hooks/useSignUp.tsx
+++ b/src/hooks/useSignUp.tsx
@@ -8,7 +8,7 @@ export type error = {
   fullName?: string;
   email?: string;
   password?: string;
-  secondPwd?: string;
+  passwordConfirm?: string;
 };
 const useSignUp = ({ initialValues, isError }) => {
   const navigate = useNavigate();
@@ -45,8 +45,13 @@ const useSignUp = ({ initialValues, isError }) => {
         })
         .catch((err) => {
           if (err.response.status === 400) {
-            alert("이메일 또는 비밀번호를 확인해주세요");
-            setValues({ fullName: "", email: "", password: "", secondPwd: "" });
+            alert("입력하신 정보를 확인해주세요");
+            setValues({
+              fullName: "",
+              email: "",
+              password: "",
+              passwordConfirm: ""
+            });
             setErrors({});
           }
         });
@@ -57,9 +62,13 @@ const useSignUp = ({ initialValues, isError }) => {
   const handleDuplicate = async () => {
     const response = await userAPI.getUserList();
     const names = response.data.map((x) => x.fullName);
-    if (names.includes(values.fullName)) {
-      alert("이미 있는 이름입니다.");
-      setValues({ fullName: "" });
+    if (isError(values).fullName === undefined) {
+      if (names.includes(values.fullName)) {
+        alert("이미 있는 이름입니다.");
+        setValues({ fullName: "" });
+      } else {
+        alert("사용가능한 이름입니다.");
+      }
     }
   };
   return {

--- a/src/hooks/useSignUp.tsx
+++ b/src/hooks/useSignUp.tsx
@@ -18,7 +18,7 @@ const useSignUp = ({ initialValues, isError }) => {
   const [errors, setErrors] = useState<error>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
-
+  const newErrors = isError(values);
   const handleChange = (e) => {
     const { name, value } = e.target;
     setValues({ ...values, [name]: value });
@@ -27,11 +27,11 @@ const useSignUp = ({ initialValues, isError }) => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setIsLoading(true);
-    const newErrors = isError(values);
 
     if (Object.keys(newErrors).length !== 0) {
       setErrors(newErrors);
     } else {
+      setErrors({});
       isChecked === false
         ? alert("닉네임 중복확인을 해주세요")
         : await authAPI
@@ -65,14 +65,17 @@ const useSignUp = ({ initialValues, isError }) => {
   const handleDuplicate = async () => {
     const response = await userAPI.getUserList();
     const names = response.data.map((x) => x.fullName);
-    if (isError(values).fullName === undefined) {
+    if (Object.keys(newErrors).length === 0) {
       if (names.includes(values.fullName)) {
-        setValues({ fullName: "" });
+        setErrors({});
+        setValues({ ...values, fullName: "" });
         alert("이미 있는 이름입니다.");
       } else {
-        setIsChecked(true);
         alert("사용가능한 이름입니다.");
+        setIsChecked(true);
       }
+    } else {
+      alert("닉네임 외 정보를 확인해주세요");
     }
   };
   return {

--- a/src/hooks/useSignUp.tsx
+++ b/src/hooks/useSignUp.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { authAPI } from "../utils/apis";
+import storage from "../utils/storage";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthProvider";
+export type error = {
+  fullName?: string;
+  email?: string;
+  password?: string;
+  secondPwd?: string;
+};
+const useSignUp = ({ initialValues, isError }) => {
+  const navigate = useNavigate();
+  const { onLogin } = useAuth();
+
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState<error>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setValues({ ...values, [name]: value });
+  };
+
+  const handleSubmit = async (e) => {
+    setIsLoading(true);
+    e.preventDefault();
+    await authAPI
+      .signUp({
+        email: values.email,
+        fullName: values.fullName,
+        password: values.password
+      })
+      .then((res) => {
+        const { user, token } = res.data;
+        onLogin(user);
+        storage.setItem("TOKEN", token);
+        navigate("/");
+      })
+      .catch((err) => {
+        if (err.response.status === 400) {
+          const newErrors = isError ? isError(values) : {};
+          if (Object.keys(newErrors).length !== 0) {
+            setErrors(newErrors);
+          } else {
+            alert("이메일 또는 비밀번호를 확인해주세요");
+            setValues({ email: "", password: "" });
+          }
+        }
+      });
+    setIsLoading(false);
+  };
+
+  return {
+    values,
+    errors,
+    isLoading,
+    handleChange,
+    handleSubmit
+  };
+};
+
+export default useSignUp;

--- a/src/hooks/useSignUp.tsx
+++ b/src/hooks/useSignUp.tsx
@@ -17,6 +17,7 @@ const useSignUp = ({ initialValues, isError }) => {
   const [values, setValues] = useState(initialValues);
   const [errors, setErrors] = useState<error>({});
   const [isLoading, setIsLoading] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -31,30 +32,32 @@ const useSignUp = ({ initialValues, isError }) => {
     if (Object.keys(newErrors).length !== 0) {
       setErrors(newErrors);
     } else {
-      await authAPI
-        .signUp({
-          email: values.email,
-          fullName: values.fullName,
-          password: values.password
-        })
-        .then((res) => {
-          const { user, token } = res.data;
-          onLogin(user);
-          storage.setItem("TOKEN", token);
-          navigate("/");
-        })
-        .catch((err) => {
-          if (err.response.status === 400) {
-            alert("입력하신 정보를 확인해주세요");
-            setValues({
-              fullName: "",
-              email: "",
-              password: "",
-              passwordConfirm: ""
+      isChecked === false
+        ? alert("닉네임 중복확인을 해주세요")
+        : await authAPI
+            .signUp({
+              email: values.email,
+              fullName: values.fullName,
+              password: values.password
+            })
+            .then((res) => {
+              const { user, token } = res.data;
+              onLogin(user);
+              storage.setItem("TOKEN", token);
+              navigate("/");
+            })
+            .catch((err) => {
+              if (err.response.status === 400) {
+                alert("입력하신 정보를 확인해주세요");
+                setValues({
+                  fullName: "",
+                  email: "",
+                  password: "",
+                  passwordConfirm: ""
+                });
+                setErrors({});
+              }
             });
-            setErrors({});
-          }
-        });
       setIsLoading(false);
     }
   };
@@ -64,9 +67,10 @@ const useSignUp = ({ initialValues, isError }) => {
     const names = response.data.map((x) => x.fullName);
     if (isError(values).fullName === undefined) {
       if (names.includes(values.fullName)) {
-        alert("이미 있는 이름입니다.");
         setValues({ fullName: "" });
+        alert("이미 있는 이름입니다.");
       } else {
+        setIsChecked(true);
         alert("사용가능한 이름입니다.");
       }
     }

--- a/src/hooks/useSignUp.tsx
+++ b/src/hooks/useSignUp.tsx
@@ -24,59 +24,34 @@ const useSignUp = ({ initialValues, isError }) => {
   };
 
   const handleSubmit = async (e) => {
+    e.preventDefault();
     setIsLoading(true);
-    e.preventDefault();
-    await authAPI
-      .signUp({
-        email: values.email,
-        fullName: values.fullName,
-        password: values.password
-      })
-      .then((res) => {
-        const { user, token } = res.data;
-        onLogin(user);
-        storage.setItem("TOKEN", token);
-        navigate("/");
-      })
-      .catch((err) => {
-        if (err.response.status === 400) {
-          const newErrors = isError ? isError(values) : {};
-          if (Object.keys(newErrors).length !== 0) {
-            setErrors(newErrors);
-          } else {
-            alert("이메일 또는 비밀번호를 확인해주세요");
-            setValues({ email: "", password: "" });
-          }
-        }
-      });
-    setIsLoading(false);
-  };
-  const testSubmit = async (e) => {
-    e.preventDefault();
-    await authAPI
-      .signUp({
-        email: values.email,
-        fullName: values.fullName,
-        password: values.password
-      })
-      .then((res) => {
-        const { user, token } = res.data;
-        console.log(user);
-        // onLogin(user);
-        // storage.setItem("TOKEN", token);
-        // navigate("/");
-      })
-      .catch((err) => {
-        if (err.response.status === 400) {
-          const newErrors = isError ? isError(values) : {};
-          if (Object.keys(newErrors).length !== 0) {
-            setErrors(newErrors);
-          } else {
+    const newErrors = isError(values);
+
+    if (Object.keys(newErrors).length !== 0) {
+      setErrors(newErrors);
+    } else {
+      await authAPI
+        .signUp({
+          email: values.email,
+          fullName: values.fullName,
+          password: values.password
+        })
+        .then((res) => {
+          const { user, token } = res.data;
+          onLogin(user);
+          storage.setItem("TOKEN", token);
+          navigate("/");
+        })
+        .catch((err) => {
+          if (err.response.status === 400) {
             alert("이메일 또는 비밀번호를 확인해주세요");
             setValues({ fullName: "", email: "", password: "", secondPwd: "" });
+            setErrors({});
           }
-        }
-      });
+        });
+      setIsLoading(false);
+    }
   };
 
   const handleDuplicate = async () => {
@@ -93,8 +68,7 @@ const useSignUp = ({ initialValues, isError }) => {
     isLoading,
     handleChange,
     handleSubmit,
-    handleDuplicate,
-    testSubmit
+    handleDuplicate
   };
 };
 

--- a/src/hooks/useSignUp.tsx
+++ b/src/hooks/useSignUp.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { authAPI } from "../utils/apis";
+import { userAPI } from "../utils/apis";
 import storage from "../utils/storage";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthProvider";
@@ -50,13 +51,50 @@ const useSignUp = ({ initialValues, isError }) => {
       });
     setIsLoading(false);
   };
+  const testSubmit = async (e) => {
+    e.preventDefault();
+    await authAPI
+      .signUp({
+        email: values.email,
+        fullName: values.fullName,
+        password: values.password
+      })
+      .then((res) => {
+        const { user, token } = res.data;
+        console.log(user);
+        // onLogin(user);
+        // storage.setItem("TOKEN", token);
+        // navigate("/");
+      })
+      .catch((err) => {
+        if (err.response.status === 400) {
+          const newErrors = isError ? isError(values) : {};
+          if (Object.keys(newErrors).length !== 0) {
+            setErrors(newErrors);
+          } else {
+            alert("이메일 또는 비밀번호를 확인해주세요");
+            setValues({ fullName: "", email: "", password: "", secondPwd: "" });
+          }
+        }
+      });
+  };
 
+  const handleDuplicate = async () => {
+    const response = await userAPI.getUserList();
+    const names = response.data.map((x) => x.fullName);
+    if (names.includes(values.fullName)) {
+      alert("이미 있는 이름입니다.");
+      setValues({ fullName: "" });
+    }
+  };
   return {
     values,
     errors,
     isLoading,
     handleChange,
-    handleSubmit
+    handleSubmit,
+    handleDuplicate,
+    testSubmit
   };
 };
 

--- a/src/pages/signUp.tsx
+++ b/src/pages/signUp.tsx
@@ -1,4 +1,0 @@
-const SignUp: React.FC = () => {
-  return <div>SignUp</div>;
-};
-export default SignUp;

--- a/src/pages/signUp/index.tsx
+++ b/src/pages/signUp/index.tsx
@@ -1,0 +1,2 @@
+import SignUp from "./signUp";
+export default SignUp;

--- a/src/pages/signUp/signUp.tsx
+++ b/src/pages/signUp/signUp.tsx
@@ -10,34 +10,27 @@ import useSignUp from "../../hooks/useSignUp";
 import type { error } from "../../hooks/useSignUp";
 const SignUp: React.FC = () => {
   const navigate = useNavigate();
-  const {
-    values,
-    errors,
-    handleChange,
-    handleSubmit,
-    handleDuplicate,
-    testSubmit
-  } = useSignUp({
-    initialValues: {
-      fullName: "",
-      email: "",
-      password: "",
-      secondPwd: ""
-    },
-    isError: ({ fullName, email, password }) => {
-      const errors: error = {};
-      if (!email) errors.email = "이메일을 입력해주세요";
-      else if (!/^.+@.+\..+$/.test(email))
-        errors.email = "올바른 이메일 형식이 아닙니다 ";
+  const { values, errors, handleChange, handleSubmit, handleDuplicate } =
+    useSignUp({
+      initialValues: {
+        fullName: "",
+        email: "",
+        password: "",
+        secondPwd: ""
+      },
+      isError: ({ fullName, email, password }) => {
+        const errors: error = {};
+        if (!email) errors.email = "이메일을 입력해주세요";
+        else if (!/^.+@.+\..+$/.test(email))
+          errors.email = "올바른 이메일 형식이 아닙니다 ";
 
-      if (!password) errors.password = "비밀번호를 입력해주세요";
-      else if (!/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]$/.test(password))
-        errors.password = "비밀번호는 하나 이상의 문자와 숫자여야 합니다";
-      else if (password.length < 6 || password.length > 12)
-        errors.password = "비밀번호는 6자리 이상 12자리 이하여야 합니다";
-      return errors;
-    }
-  });
+        if (!password) errors.password = "비밀번호를 입력해주세요";
+        else if (!/^(?=.*[a-zA-Z])(?=.*[0-9]).{6,12}$/.test(password))
+          errors.password =
+            "비밀번호는 숫자, 영문자로 이루어진 6~12자리여야 합니다";
+        return errors;
+      }
+    });
   return (
     <AppLayout>
       <S.SignUpWrapper>
@@ -50,10 +43,11 @@ const SignUp: React.FC = () => {
             label="닉네임"
             name="fullName"
             value={values.fullName}
+            placeholder="닉네임을 입력해주세요"
             onChange={handleChange}
             errorMessage={errors.fullName}
           />
-          <Button buttonType="red-line" onClick={handleDuplicate}>
+          <Button buttonType="red-line" width={"120"} onClick={handleDuplicate}>
             중복 확인
           </Button>
         </S.ConfirmWrapper>
@@ -62,6 +56,7 @@ const SignUp: React.FC = () => {
             label="이메일"
             name="email"
             value={values.email}
+            placeholder="이메일을 입력해주세요"
             onChange={handleChange}
             errorMessage={errors.email}
           />
@@ -72,6 +67,7 @@ const SignUp: React.FC = () => {
             name="password"
             type="password"
             value={values.password}
+            placeholder="비밀번호를 입력해주세요"
             onChange={handleChange}
             errorMessage={errors.password}
           />
@@ -82,12 +78,13 @@ const SignUp: React.FC = () => {
             name="secondPwd"
             type="password"
             value={values.secondPwd}
+            placeholder="비밀번호를 다시 입력해주세요"
             onChange={handleChange}
             errorMessage={errors.secondPwd}
           />
         </S.MarginWrapper>
         <S.MarginWrapper>
-          <Button onClick={testSubmit}>Sign Up</Button>
+          <Button>Sign Up</Button>
         </S.MarginWrapper>
       </S.SignUpWrapper>
       <button onClick={handleDuplicate}>get user</button>

--- a/src/pages/signUp/signUp.tsx
+++ b/src/pages/signUp/signUp.tsx
@@ -10,7 +10,14 @@ import useSignUp from "../../hooks/useSignUp";
 import type { error } from "../../hooks/useSignUp";
 const SignUp: React.FC = () => {
   const navigate = useNavigate();
-  const { values, errors, handleChange, handleSubmit } = useSignUp({
+  const {
+    values,
+    errors,
+    handleChange,
+    handleSubmit,
+    handleDuplicate,
+    testSubmit
+  } = useSignUp({
     initialValues: {
       fullName: "",
       email: "",
@@ -46,7 +53,9 @@ const SignUp: React.FC = () => {
             onChange={handleChange}
             errorMessage={errors.fullName}
           />
-          <Button buttonType="red-line">중복 확인</Button>
+          <Button buttonType="red-line" onClick={handleDuplicate}>
+            중복 확인
+          </Button>
         </S.ConfirmWrapper>
         <S.MarginWrapper>
           <InputBox
@@ -78,9 +87,10 @@ const SignUp: React.FC = () => {
           />
         </S.MarginWrapper>
         <S.MarginWrapper>
-          <Button>로그인</Button>
+          <Button onClick={testSubmit}>Sign Up</Button>
         </S.MarginWrapper>
       </S.SignUpWrapper>
+      <button onClick={handleDuplicate}>get user</button>
     </AppLayout>
   );
 };

--- a/src/pages/signUp/signUp.tsx
+++ b/src/pages/signUp/signUp.tsx
@@ -16,10 +16,13 @@ const SignUp: React.FC = () => {
         fullName: "",
         email: "",
         password: "",
-        secondPwd: ""
+        passwordConfirm: ""
       },
-      isError: ({ fullName, email, password }) => {
+      isError: ({ fullName, email, password, passwordConfirm }) => {
         const errors: error = {};
+        if (!fullName) errors.fullName = "닉네임을 입력해주세요";
+        else if (!/^[ㄱ-ㅎ|가-힣|a-z|A-Z|0-9|].{2,8}$/.test(fullName))
+          errors.fullName = "닉네임은 2~8자리여야 합니다";
         if (!email) errors.email = "이메일을 입력해주세요";
         else if (!/^.+@.+\..+$/.test(email))
           errors.email = "올바른 이메일 형식이 아닙니다 ";
@@ -28,6 +31,11 @@ const SignUp: React.FC = () => {
         else if (!/^(?=.*[a-zA-Z])(?=.*[0-9]).{6,12}$/.test(password))
           errors.password =
             "비밀번호는 숫자, 영문자로 이루어진 6~12자리여야 합니다";
+
+        if (!passwordConfirm)
+          errors.passwordConfirm = "비밀번호 확인을 입력해주세요";
+        else if (passwordConfirm != password)
+          errors.passwordConfirm = "위에 입력한 비밀번호와 같지 않습니다";
         return errors;
       }
     });
@@ -75,19 +83,18 @@ const SignUp: React.FC = () => {
         <S.MarginWrapper>
           <InputBox
             label="비밀번호 확인"
-            name="secondPwd"
+            name="passwordConfirm"
             type="password"
-            value={values.secondPwd}
+            value={values.passwordConfirm}
             placeholder="비밀번호를 다시 입력해주세요"
             onChange={handleChange}
-            errorMessage={errors.secondPwd}
+            errorMessage={errors.passwordConfirm}
           />
         </S.MarginWrapper>
         <S.MarginWrapper>
-          <Button>Sign Up</Button>
+          <Button onClick={handleSubmit}>Sign Up</Button>
         </S.MarginWrapper>
       </S.SignUpWrapper>
-      <button onClick={handleDuplicate}>get user</button>
     </AppLayout>
   );
 };

--- a/src/pages/signUp/signUp.tsx
+++ b/src/pages/signUp/signUp.tsx
@@ -1,0 +1,87 @@
+import * as S from "./style";
+import {
+  InputBox,
+  Button,
+  AppLayout,
+  logoImg
+} from "../../components/signIn/index";
+import { useNavigate } from "react-router";
+import useSignUp from "../../hooks/useSignUp";
+import type { error } from "../../hooks/useSignUp";
+const SignUp: React.FC = () => {
+  const navigate = useNavigate();
+  const { values, errors, handleChange, handleSubmit } = useSignUp({
+    initialValues: {
+      fullName: "",
+      email: "",
+      password: "",
+      secondPwd: ""
+    },
+    isError: ({ fullName, email, password }) => {
+      const errors: error = {};
+      if (!email) errors.email = "이메일을 입력해주세요";
+      else if (!/^.+@.+\..+$/.test(email))
+        errors.email = "올바른 이메일 형식이 아닙니다 ";
+
+      if (!password) errors.password = "비밀번호를 입력해주세요";
+      else if (!/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]$/.test(password))
+        errors.password = "비밀번호는 하나 이상의 문자와 숫자여야 합니다";
+      else if (password.length < 6 || password.length > 12)
+        errors.password = "비밀번호는 6자리 이상 12자리 이하여야 합니다";
+      return errors;
+    }
+  });
+  return (
+    <AppLayout>
+      <S.SignUpWrapper>
+        <S.Image>
+          <img src={logoImg} alt="로고" onClick={() => navigate("/")} />
+        </S.Image>
+        <S.H2>회원가입</S.H2>
+        <S.ConfirmWrapper>
+          <InputBox
+            label="닉네임"
+            name="fullName"
+            value={values.fullName}
+            onChange={handleChange}
+            errorMessage={errors.fullName}
+          />
+          <Button buttonType="red-line">중복 확인</Button>
+        </S.ConfirmWrapper>
+        <S.MarginWrapper>
+          <InputBox
+            label="이메일"
+            name="email"
+            value={values.email}
+            onChange={handleChange}
+            errorMessage={errors.email}
+          />
+        </S.MarginWrapper>
+        <S.MarginWrapper>
+          <InputBox
+            label="비밀번호"
+            name="password"
+            type="password"
+            value={values.password}
+            onChange={handleChange}
+            errorMessage={errors.password}
+          />
+        </S.MarginWrapper>
+        <S.MarginWrapper>
+          <InputBox
+            label="비밀번호 확인"
+            name="secondPwd"
+            type="password"
+            value={values.secondPwd}
+            onChange={handleChange}
+            errorMessage={errors.secondPwd}
+          />
+        </S.MarginWrapper>
+        <S.MarginWrapper>
+          <Button>로그인</Button>
+        </S.MarginWrapper>
+      </S.SignUpWrapper>
+    </AppLayout>
+  );
+};
+export default SignUp;

--- a/src/pages/signUp/style.tsx
+++ b/src/pages/signUp/style.tsx
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 
 export const SignUpWrapper = styled.div`
-  margin: 20px 25%;
+  margin: 0 25%;
 `;
 
 export const Image = styled.div`
   text-align: center;
-  margin: 40px 0;
+  padding: 20px 0;
   cursor: pointer;
 `;
 
@@ -23,4 +23,11 @@ export const MarginWrapper = styled.div`
 export const ConfirmWrapper = styled.div`
   margin: 30px 0;
   display: flex;
+  div {
+    flex-grow: 2;
+    margin-right: 10px;
+  }
+  button {
+    margin-top: 22px;
+  }
 `;

--- a/src/pages/signUp/style.tsx
+++ b/src/pages/signUp/style.tsx
@@ -1,0 +1,26 @@
+import styled from "@emotion/styled";
+
+export const SignUpWrapper = styled.div`
+  margin: 20px 25%;
+`;
+
+export const Image = styled.div`
+  text-align: center;
+  margin: 40px 0;
+  cursor: pointer;
+`;
+
+export const H2 = styled.h2`
+  font-weight: bold;
+  text-align: center;
+  margin: 40px 0;
+`;
+
+export const MarginWrapper = styled.div`
+  margin: 30px 0;
+`;
+
+export const ConfirmWrapper = styled.div`
+  margin: 30px 0;
+  display: flex;
+`;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -7,7 +7,7 @@ import Home from "../pages/home";
 import Profile from "../pages/profile/profile";
 import Result from "../pages/search";
 import SignIn from "../pages/signIn/signIn";
-import SignUp from "../pages/signUp";
+import SignUp from "../pages/signUp/signUp";
 
 const AppRouter: React.FC = () => {
   return (


### PR DESCRIPTION
# 개요
회원 가입 페이지 구현
# 작업 내용
* 각 값에 따른 에러메세지 노출
* 닉네임 중복 확인을 하지 않으면 가입이 되지 않음 (중복 확인 요청 alert)
* 회원 가입 성공 시 로그인한 상태로 **메인으로 이동** 
(이게 더 나아보여서 로그인 페이지 대신 메인으로 이동하는 것으로 했습니다, 수정 필요하면 말씀해주세요!)

✅  API 구조상 닉네임이 안겹치면 예전에 가입한 이메일로도 가입 가능...
✅  로그인 페이지와 겹치는 내용이 많아서 merge후 같이 리팩토링하려고 합니다 
# 관련 이슈
close #38 
# 사진
## 가입 양식 확인 에러 메세지

https://user-images.githubusercontent.com/95457808/174561208-06a675d4-7153-4141-8c9a-01a354853c5e.mp4


## 중복 확인 후 가입 완료
https://user-images.githubusercontent.com/95457808/174560487-dcd7306b-6c86-4e5b-89f1-ed58120a60d9.mp4


<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
