### PR TITLE
✨ feat: 상세 페이지 post 삭제, 좋아요, 권한 작업

### DIFF
--- a/src/components/detail/PostBody/PostBody.tsx
+++ b/src/components/detail/PostBody/PostBody.tsx
@@ -4,10 +4,16 @@ import theme from "../../../styles/theme";
 interface PostBodyInterface {
   introduction: string;
   postEdit: React.MouseEventHandler<HTMLButtonElement>;
+  postDelete: React.MouseEventHandler<HTMLButtonElement>;
+  isAuthor: boolean;
 }
 
-const PostBody: React.FC<PostBodyInterface> = ({ introduction, postEdit }) => {
-  const isAuthor = true; // 추후 Context API로 구현
+const PostBody: React.FC<PostBodyInterface> = ({
+  introduction,
+  postEdit,
+  postDelete,
+  isAuthor
+}) => {
   return (
     <S.PostBody>
       {/* 추후 global font로 교체 예정 */}
@@ -19,7 +25,7 @@ const PostBody: React.FC<PostBodyInterface> = ({ introduction, postEdit }) => {
           <Button buttonType="gray-line" width="100" onClick={postEdit}>
             수정
           </Button>
-          <Button buttonType="gray-line" width="100">
+          <Button buttonType="gray-line" width="100" onClick={postDelete}>
             삭제
           </Button>
         </S.Wrapper>

--- a/src/components/detail/PostFooter/Comment/Comment.tsx
+++ b/src/components/detail/PostFooter/Comment/Comment.tsx
@@ -6,8 +6,10 @@ interface CommentInterface {
   key: string;
   commentId: string;
   comment: string;
+  userId: string;
   comments: object[];
   author: string;
+  authorId: string;
   updatedAt: string;
   deleteComment: (value: object, id: string) => void;
 }
@@ -15,7 +17,9 @@ interface CommentInterface {
 const Comment: React.FC<CommentInterface> = ({
   commentId,
   comment,
+  userId,
   author,
+  authorId,
   updatedAt,
   deleteComment
 }) => {
@@ -31,12 +35,20 @@ const Comment: React.FC<CommentInterface> = ({
       <S.CommentText>{comment}</S.CommentText>
       <S.DeleteCommetDiv>
         <span></span>
-        <span
-          onClick={(e) => deleteComment(e, commentId)}
-          style={{ textDecoration: "underline", color: theme.$gray600 }}
-        >
-          댓글삭제
-        </span>
+        {userId === authorId ? (
+          <span
+            onClick={(e) => deleteComment(e, commentId)}
+            style={{
+              height: "14px",
+              textDecoration: "underline",
+              color: theme.$gray600
+            }}
+          >
+            댓글삭제
+          </span>
+        ) : (
+          <span style={{ height: "14px" }}></span>
+        )}
       </S.DeleteCommetDiv>
       <S.CommentHorizontalRule color={theme.$gray200} />
     </div>

--- a/src/components/detail/PostFooter/PostFooter.tsx
+++ b/src/components/detail/PostFooter/PostFooter.tsx
@@ -6,6 +6,8 @@ import { useEffect, useState } from "react";
 interface PostFooterInterface {
   comments: object[];
   postId: string;
+  userId: string;
+  isLoggedIn: boolean;
   setComments: (value: object) => void;
   deleteComment: (value: object, id: string) => void;
 }
@@ -13,11 +15,14 @@ interface PostFooterInterface {
 const PostFooter: React.FC<PostFooterInterface> = ({
   comments,
   postId,
+  userId,
+  isLoggedIn,
   setComments,
   deleteComment
 }) => {
   let paramComment;
   let paramAuthor;
+  let paramAuthorId;
   let paramUpdatedAt;
   let paramKey;
 
@@ -28,6 +33,8 @@ const PostFooter: React.FC<PostFooterInterface> = ({
         postId={postId}
         comments={comments}
         setComments={setComments}
+        isLoggedIn={isLoggedIn}
+        userId={userId}
       ></TextareaBox>
       <div>
         {comments.map((comment) => {
@@ -40,6 +47,7 @@ const PostFooter: React.FC<PostFooterInterface> = ({
                   break;
                 case "author":
                   paramAuthor = comment[prop].fullName;
+                  paramAuthorId = comment[prop]._id;
                   break;
                 case "updatedAt":
                   paramUpdatedAt = comment[prop]
@@ -57,6 +65,8 @@ const PostFooter: React.FC<PostFooterInterface> = ({
           return (
             <Comment
               key={paramKey}
+              userId={userId}
+              authorId={paramAuthorId}
               commentId={paramKey}
               comment={paramComment}
               author={paramAuthor}

--- a/src/components/detail/PostFooter/TextareaBox/TextareaBox.tsx
+++ b/src/components/detail/PostFooter/TextareaBox/TextareaBox.tsx
@@ -8,15 +8,19 @@ interface TextareaBoxInterface {
   postId: string;
   comments: object[];
   setComments: (value: object) => void;
+  isLoggedIn: boolean;
+  userId: string;
 }
 
 const TextareaBox: React.FC<TextareaBoxInterface> = ({
   length,
   postId,
   comments,
-  setComments
+  setComments,
+  isLoggedIn,
+  userId
 }) => {
-  const isLoggedIn = true; // 추후 Context API로 변경
+  //const isLoggedIn = true; // 추후 Context API로 변경
   const [commentText, setCommentText] = useState("");
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const onCommentChange = (event) => {
@@ -39,53 +43,45 @@ const TextareaBox: React.FC<TextareaBoxInterface> = ({
           ...comments,
           {
             comment: commentText,
-            post: postId
+            post: postId,
+            author: {
+              _id: userId
+            }
           }
         ]);
       } catch (error) {
         console.error(error);
       }
     }
+    console.log(comments);
   };
 
   return (
     <div>
       <S.Section>{length}개의 댓글이 있습니다.</S.Section>
       <hr color="#FFD613" />
-      {isLoggedIn ? (
-        <div>
-          <S.Textarea>
-            <Textarea
-              isIntroduction={false}
-              isLogin={true}
-              onChange={onCommentChange}
-              textAreaRef={textAreaRef}
-            ></Textarea>
-          </S.Textarea>
-          <S.SubmitDiv>
-            <div></div>
-            <Button
-              buttonType="blue"
-              isRound={true}
-              width="200"
-              onClick={createComment}
-            >
-              댓글 등록
-            </Button>
-          </S.SubmitDiv>
-        </div>
-      ) : (
-        <div></div>
-      )}
-      {/* <S.Textarea>
-        <Textarea isIntroduction={false} isLogin={true}></Textarea>
-      </S.Textarea>
-      <S.SubmitDiv>
-        <div></div>
-        <Button buttonType="blue" isRound={true} width="200">
-          댓글 등록
-        </Button>
-      </S.SubmitDiv> */}
+      <div>
+        <S.Textarea>
+          <Textarea
+            isIntroduction={false}
+            isLogin={isLoggedIn}
+            onChange={onCommentChange}
+            textAreaRef={textAreaRef}
+          ></Textarea>
+        </S.Textarea>
+        <S.SubmitDiv>
+          <div></div>
+          <Button
+            buttonType={isLoggedIn ? "blue" : "gray"}
+            isRound={true}
+            width="200"
+            onClick={createComment}
+            isDisabled={!isLoggedIn}
+          >
+            댓글 등록
+          </Button>
+        </S.SubmitDiv>
+      </div>
     </div>
   );
 };

--- a/src/components/detail/PostHeader/PostHeader.tsx
+++ b/src/components/detail/PostHeader/PostHeader.tsx
@@ -2,12 +2,18 @@ import React from "react";
 import PostTitle from "./PostTitle";
 import ProfileImage from "../../common/ProfileImage/index";
 import PostSummary from "./PostSummary";
+import LikeBtn from "../../common/LikeBtn";
+import { ILike } from "src/types/model";
 import { ReactComponent as BackIcon } from "../../../assets/icons/icon_back.svg";
 import { ReactComponent as HeartIcon } from "../../../assets/icons/icon_heart.svg";
 import { ReactComponent as HeartFillIcon } from "../../../assets/icons/icon_heart_fill.svg";
+import { useNavigate } from "react-router-dom";
 import * as S from "./style";
 
 interface PostHeaderInterface {
+  postId: string;
+  userId: string;
+  likes: ILike[];
   title: string;
   authorId: string;
   createdAt: string;
@@ -21,6 +27,9 @@ interface PostHeaderInterface {
 }
 
 const PostHeader: React.FC<PostHeaderInterface> = ({
+  postId,
+  userId,
+  likes,
   title,
   authorId,
   createdAt,
@@ -32,15 +41,18 @@ const PostHeader: React.FC<PostHeaderInterface> = ({
   expectedDate,
   skills
 }) => {
+  const homeNavigate = useNavigate();
+  const backButtonClick = () => {
+    homeNavigate("/");
+  };
   return (
     <>
       <S.FlexBetween>
-        <span>
+        <span onClick={backButtonClick}>
           <BackIcon />
         </span>
         <S.CenterAlignItemSpan>
-          <HeartIcon />
-          <span>12{/* 추후에 받아올 예정 */}</span>
+          <LikeBtn likes={likes} userId={userId} postId={postId} />
         </S.CenterAlignItemSpan>
       </S.FlexBetween>
       <PostTitle>{title}</PostTitle>


### PR DESCRIPTION
# 개요
상세 페이지 post 삭제, 좋아요, 권한 작업

# 작업 내용
- 게시글 삭제 API 통신 추가
- 좋아요 기능 추가
- 권한 별로 수정/삭제, 댓글 등록/삭제 요소 다르게 보이기

# 관련 이슈
- 댓글 등록 시 setState에 추가 Comment 추가 부분에서 Comment id를 불러오는 방법을 찾아야됩니다.

# 사진
- 게시글 삭제

https://user-images.githubusercontent.com/15838144/174574411-c565a2a5-4cde-4f16-b60f-b3d56ce699b1.mov

- 좋아요/해제


https://user-images.githubusercontent.com/15838144/174574890-a9577416-4dee-4527-8998-4b013c34f8ff.mov


- 권한 처리


https://user-images.githubusercontent.com/15838144/174575227-d0656144-dbff-4a4c-8b54-e26eb1f017ad.mov



closes #220 
