### PR TITLE
:sparkles: feat: 생성페이지에서 ImageUploader 서버 통신 구현

### DIFF
--- a/src/components/create/ImageUploader/ImageUploader.tsx
+++ b/src/components/create/ImageUploader/ImageUploader.tsx
@@ -3,8 +3,15 @@ import ImageUploading, { ImageListType } from "react-images-uploading";
 import { UploadOutlined, DeleteOutlined } from "@ant-design/icons";
 import { Button, Upload } from "antd";
 import * as S from "./style";
-const ImageUploader: React.FC = () => {
-  const [images, setImages] = React.useState([]);
+
+interface ImageUploaderInterface {
+  images: any[];
+  setImages: React.Dispatch<React.SetStateAction<any[]>>;
+}
+const ImageUploader: React.FC<ImageUploaderInterface> = ({
+  images,
+  setImages
+}) => {
   const maxNumber = 69;
 
   const onChange = (

--- a/src/pages/create/create.tsx
+++ b/src/pages/create/create.tsx
@@ -33,6 +33,7 @@ const expectedDateOptions = [
 const Create: React.FC = () => {
   const navigate = useNavigate();
 
+  const [images, setImages] = useState([]);
   const [_title, setTitle] = useState("");
   const [place, setPlace] = useState("online");
   const [email, setEmail] = useState("");
@@ -71,7 +72,7 @@ const Create: React.FC = () => {
       });
       const formData = new FormData();
       formData.append("title", title);
-      formData.append("image", null);
+      formData.append("image", images[0].file);
       formData.append("channelId", currentChannelId);
       const getPost = async (formData: FormData) => {
         await postAPI.createPost(formData).then((res) => {
@@ -163,10 +164,10 @@ const Create: React.FC = () => {
       >
         {introduction}
       </Textarea>
+      <ImageUploader images={images} setImages={setImages} />
       <Button isRound={true} width="300" onClick={handleCreate}>
         생성하기
       </Button>
-      <ImageUploader />
     </AppLayout>
   );
 };


### PR DESCRIPTION
# 개요
- [x] 생성페이지에서 ImageUploader 서버통신
(형진님 상세페이지에서 이미지 보이도록  + 수정페이지로 넘기실 때 PublicId도 .. 부탁드려용 😳)

<img width="446" alt="스크린샷 2022-06-20 오후 7 37 33" src="https://user-images.githubusercontent.com/72402747/174584136-35bc27c3-6d9e-4941-924c-48151f5cabd3.png">

# 작업 내용


# 사진
완료 후 PublicId를 잘 받아오고 있습니다
<img width="424" alt="스크린샷 2022-06-20 오후 7 35 50" src="https://user-images.githubusercontent.com/72402747/174583875-a3334a94-37a4-45af-816b-363502d5643f.png">




close #228 
<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
