### PR TITLE
🐛 fix: [상세페이지] 프로필 사진 조회, 댓글 등록 기능 fix

### DIFF
--- a/src/components/detail/PostFooter/Comment/Comment.tsx
+++ b/src/components/detail/PostFooter/Comment/Comment.tsx
@@ -10,6 +10,7 @@ interface CommentInterface {
   comments: object[];
   author: string;
   authorId: string;
+  authorImage: string;
   updatedAt: string;
   deleteComment: (value: object, id: string) => void;
 }
@@ -20,6 +21,7 @@ const Comment: React.FC<CommentInterface> = ({
   userId,
   author,
   authorId,
+  authorImage,
   updatedAt,
   deleteComment
 }) => {
@@ -27,7 +29,12 @@ const Comment: React.FC<CommentInterface> = ({
     <div>
       <S.FlexBetween>
         <S.CenterAlignItemSpan>
-          <ProfileImage block={false} size="md" />
+          {/* <ProfileImage block={false} size="md" /> */}
+          <ProfileImage
+            size="sm"
+            imgAlt={author ? author : null}
+            imgSrc={authorImage ? authorImage : null}
+          />
           <span>{author}</span>
         </S.CenterAlignItemSpan>
         <span style={{ color: theme.$gray400 }}>{updatedAt}</span>

--- a/src/components/detail/PostFooter/PostFooter.tsx
+++ b/src/components/detail/PostFooter/PostFooter.tsx
@@ -7,6 +7,9 @@ interface PostFooterInterface {
   comments: object[];
   postId: string;
   userId: string;
+  userName: string;
+  userImage: string;
+  postAuthorId: string;
   isLoggedIn: boolean;
   setComments: (value: object) => void;
   deleteComment: (value: object, id: string) => void;
@@ -16,6 +19,9 @@ const PostFooter: React.FC<PostFooterInterface> = ({
   comments,
   postId,
   userId,
+  userName,
+  userImage,
+  postAuthorId,
   isLoggedIn,
   setComments,
   deleteComment
@@ -23,6 +29,7 @@ const PostFooter: React.FC<PostFooterInterface> = ({
   let paramComment;
   let paramAuthor;
   let paramAuthorId;
+  let paramAuthorImage;
   let paramUpdatedAt;
   let paramKey;
 
@@ -35,6 +42,9 @@ const PostFooter: React.FC<PostFooterInterface> = ({
         setComments={setComments}
         isLoggedIn={isLoggedIn}
         userId={userId}
+        userName={userName}
+        userImage={userImage}
+        postAuthorId={postAuthorId}
       ></TextareaBox>
       <div>
         {comments.map((comment) => {
@@ -48,6 +58,7 @@ const PostFooter: React.FC<PostFooterInterface> = ({
                 case "author":
                   paramAuthor = comment[prop].fullName;
                   paramAuthorId = comment[prop]._id;
+                  paramAuthorImage = comment[prop].image;
                   break;
                 case "updatedAt":
                   paramUpdatedAt = comment[prop]
@@ -67,6 +78,7 @@ const PostFooter: React.FC<PostFooterInterface> = ({
               key={paramKey}
               userId={userId}
               authorId={paramAuthorId}
+              authorImage={paramAuthorImage}
               commentId={paramKey}
               comment={paramComment}
               author={paramAuthor}

--- a/src/components/detail/PostFooter/TextareaBox/TextareaBox.tsx
+++ b/src/components/detail/PostFooter/TextareaBox/TextareaBox.tsx
@@ -11,6 +11,9 @@ interface TextareaBoxInterface {
   setComments: (value: object) => void;
   isLoggedIn: boolean;
   userId: string;
+  userName: string;
+  userImage: string;
+  postAuthorId: string;
 }
 
 const TextareaBox: React.FC<TextareaBoxInterface> = ({
@@ -19,7 +22,10 @@ const TextareaBox: React.FC<TextareaBoxInterface> = ({
   comments,
   setComments,
   isLoggedIn,
-  userId
+  userId,
+  userName,
+  userImage,
+  postAuthorId
 }) => {
   //const isLoggedIn = true; // 추후 Context API로 변경
   const [commentText, setCommentText] = useState("");
@@ -39,30 +45,38 @@ const TextareaBox: React.FC<TextareaBoxInterface> = ({
           comment: commentText,
           postId: postId
         });
-        setCommentText(() => "");
         const { _id } = createCommentRespon.data;
-        /* setComments((comments) => [ 이건 꼭 구현하자... ㅠㅠ
+        const now = new Date();
+        const today =
+          now.getFullYear() + "." + (now.getMonth() + 1) + "." + now.getDate();
+        setComments((comments) => [
           ...comments,
           {
+            _id: _id,
             comment: commentText,
             post: postId,
             author: {
-              _id: userId
-            }
+              _id: userId,
+              fullName: userName,
+              image: userImage
+            },
+            createdAt: today,
+            updatedAt: today
           }
-        ]); */
+        ]);
         await notificationAPI.createNotification({
           notificationType: "COMMENT",
           notificationTypeId: _id,
-          userId: userId,
+          userId: postAuthorId,
           postId: postId
         });
+        textAreaRef.current.value = "";
       } catch (error) {
         console.error(error);
       }
-      location.reload();
+      //location.reload();
     }
-    console.log(comments);
+    //console.log(comments);
   };
 
   return (

--- a/src/components/detail/PostHeader/PostHeader.tsx
+++ b/src/components/detail/PostHeader/PostHeader.tsx
@@ -3,11 +3,12 @@ import PostTitle from "./PostTitle";
 import ProfileImage from "../../common/ProfileImage/index";
 import PostSummary from "./PostSummary";
 import LikeBtn from "../../common/LikeBtn";
-import { ILike } from "src/types/model";
+import { ILike, IUser } from "src/types/model";
 import { ReactComponent as BackIcon } from "../../../assets/icons/icon_back.svg";
 import { ReactComponent as HeartIcon } from "../../../assets/icons/icon_heart.svg";
 import { ReactComponent as HeartFillIcon } from "../../../assets/icons/icon_heart_fill.svg";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "@contexts/AuthProvider";
 import * as S from "./style";
 
 interface PostHeaderInterface {
@@ -16,6 +17,7 @@ interface PostHeaderInterface {
   likes: ILike[];
   title: string;
   authorId: string;
+  authorImage: string;
   createdAt: string;
   channel: string;
   people: string;
@@ -32,6 +34,7 @@ const PostHeader: React.FC<PostHeaderInterface> = ({
   likes,
   title,
   authorId,
+  authorImage,
   createdAt,
   channel,
   people,
@@ -58,7 +61,11 @@ const PostHeader: React.FC<PostHeaderInterface> = ({
       <PostTitle>{title}</PostTitle>
       <S.FlexBetween style={{ alignItems: "end" }}>
         <S.CenterAlignItemSpan>
-          <ProfileImage block={false} size={"md"}></ProfileImage>
+          <ProfileImage
+            size="sm"
+            imgAlt={authorId ? authorId : null}
+            imgSrc={authorImage ? authorImage : null}
+          />
           <span>{authorId}</span>
         </S.CenterAlignItemSpan>
         <span>{createdAt}</span>

--- a/src/components/detail/PostHeader/PostHeader.tsx
+++ b/src/components/detail/PostHeader/PostHeader.tsx
@@ -5,10 +5,7 @@ import PostSummary from "./PostSummary";
 import LikeBtn from "../../common/LikeBtn";
 import { ILike, IUser } from "src/types/model";
 import { ReactComponent as BackIcon } from "../../../assets/icons/icon_back.svg";
-import { ReactComponent as HeartIcon } from "../../../assets/icons/icon_heart.svg";
-import { ReactComponent as HeartFillIcon } from "../../../assets/icons/icon_heart_fill.svg";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "@contexts/AuthProvider";
 import * as S from "./style";
 
 interface PostHeaderInterface {
@@ -18,7 +15,7 @@ interface PostHeaderInterface {
   title: string;
   authorId: string;
   authorImage: string;
-  createdAt: string;
+  updatedAt: string;
   channel: string;
   people: string;
   email: string;
@@ -35,7 +32,7 @@ const PostHeader: React.FC<PostHeaderInterface> = ({
   title,
   authorId,
   authorImage,
-  createdAt,
+  updatedAt,
   channel,
   people,
   email,
@@ -68,7 +65,7 @@ const PostHeader: React.FC<PostHeaderInterface> = ({
           />
           <span>{authorId}</span>
         </S.CenterAlignItemSpan>
-        <span>{createdAt}</span>
+        <span>{updatedAt}</span>
       </S.FlexBetween>
       <br></br>
       <S.PostSection>요약</S.PostSection>

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -163,6 +163,10 @@ const Detail: React.FC<DetailInterface> = ({ post = null }) => {
       }
     }
   }
+  const localDate = new Date(postDetail.updatedAt)
+    .toLocaleDateString()
+    .replaceAll(" ", "")
+    .substring(0, 9);
   return (
     <AppLayout>
       <div>
@@ -173,7 +177,7 @@ const Detail: React.FC<DetailInterface> = ({ post = null }) => {
           title={paramTitle}
           authorId={postDetail.author.fullName}
           authorImage={postDetail.author.image}
-          createdAt={postDetail.updatedAt.substring(0, 10).replaceAll("-", ".")}
+          updatedAt={localDate}
           channel={paramChannel}
           people={paramPeople}
           email={paramEmail}

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -9,6 +9,7 @@ import commentAPI from "@utils/apis/comment";
 import authAPI from "@utils/apis/auth";
 import { IPost, IComment } from "../../types/model";
 import storage from "@utils/storage";
+import { useAuth } from "@contexts/AuthProvider";
 
 type DetailInterface = { post?: IPost };
 
@@ -17,6 +18,7 @@ const Detail: React.FC<DetailInterface> = ({ post = null }) => {
   const [titleObj, setTitleObj] = useState({});
   const [comments, setComments] = useState([]);
   const [userId, setUserId] = useState("");
+  const { onLogOut, userInfo } = useAuth();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const editNavigate = useNavigate();
   const homeNavigate = useNavigate();
@@ -170,6 +172,7 @@ const Detail: React.FC<DetailInterface> = ({ post = null }) => {
           likes={likes}
           title={paramTitle}
           authorId={postDetail.author.fullName}
+          authorImage={postDetail.author.image}
           createdAt={postDetail.updatedAt.substring(0, 10).replaceAll("-", ".")}
           channel={paramChannel}
           people={paramPeople}
@@ -189,7 +192,10 @@ const Detail: React.FC<DetailInterface> = ({ post = null }) => {
         <PostFooter
           comments={comments}
           userId={userId}
+          userImage={userInfo.image}
+          userName={userInfo.fullName}
           postId={postId}
+          postAuthorId={postDetail.author._id}
           isLoggedIn={isLoggedIn}
           setComments={setComments}
           deleteComment={deleteComment}


### PR DESCRIPTION
# 개요
[상세페이지] 프로필 사진 조회 수정, 댓글 등록 비동기 방식 구현

# 작업 내용
프로필 사진 조회
- 게시물 작성자, 댓글 작성자의 프로필 사진이 안보이는 현상 fix

댓글 등록
- 댓글 등록 후 Location.reload()에서 댓글 상태 관리를 통해 비동기 방식으로 fix
- 댓글 등록 후 알림 대상을 게시물 작성자로 fix

시간
- 게시글의 updatedAt 정보를 현지 시간으로 변경 

# 관련 이슈
closes #239 

# 사진
- 게시글 작성자 프로필 정보

![image](https://user-images.githubusercontent.com/15838144/174668702-dc9480b1-3329-4d5f-88f5-8a5b538b60ea.png)


- 댓글 작성자 프로필 정보

![image](https://user-images.githubusercontent.com/15838144/174668731-8d062a34-a547-4d1d-a1ee-dcf88a83512d.png)


- 댓글 비동기 처리


https://user-images.githubusercontent.com/15838144/174671508-8121c548-ea87-4a59-9a86-48b4cc8afe20.mov


