### PR TITLE
✨ feat: 유저 정보에 서버 API 및 context 연결

### DIFF
--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -7,9 +7,16 @@ import { IPost } from "../../../types/model";
 import LikeBtn from "../LikeBtn";
 import * as S from "./style";
 
-type CardInterface = { post?: IPost } & { userId?: string };
+type CardInterface = { post?: IPost } & {
+  userId?: string;
+  clickable?: boolean;
+};
 
-const Card: React.FC<CardInterface> = ({ post, userId = null }) => {
+const Card: React.FC<CardInterface> = ({
+  post,
+  userId = null,
+  clickable = true
+}) => {
   const postTitle = post ? JSON.parse(post.title) : dummy;
   const { _id, author, likes } = post;
   const { title, parts, expectedDate, startDate } = postTitle;
@@ -25,7 +32,12 @@ const Card: React.FC<CardInterface> = ({ post, userId = null }) => {
         <S.Tag color={channelColor[parts.channel].color}>
           {channelColor[parts.channel].title}
         </S.Tag>
-        <LikeBtn likes={likes} userId={userId} postId={_id} />
+        <LikeBtn
+          likes={likes}
+          userId={userId}
+          postId={_id}
+          clickable={clickable}
+        />
       </S.FlexBetween>
       <S.Title>{title}</S.Title>
       <span>모집인원: {parts.people}</span>

--- a/src/components/common/LikeBtn/LikeBtn.tsx
+++ b/src/components/common/LikeBtn/LikeBtn.tsx
@@ -9,9 +9,15 @@ type LikeBtnInterface = {
   likes: ILike[];
   postId: string;
   userId?: string;
+  clickable?: boolean;
 };
 
-const LikeBtn: React.FC<LikeBtnInterface> = ({ likes, postId, userId }) => {
+const LikeBtn: React.FC<LikeBtnInterface> = ({
+  likes,
+  postId,
+  userId,
+  clickable = true
+}) => {
   const [likeId, setLikeId] = useState<string>(null);
   const [totalLike, setTotalLike] = useState(0);
 
@@ -41,7 +47,11 @@ const LikeBtn: React.FC<LikeBtnInterface> = ({ likes, postId, userId }) => {
   }, [likes]);
 
   return (
-    <S.LikeBtn onClick={userId ? clickLikeBtn : null} userId={userId}>
+    <S.LikeBtn
+      onClick={userId && clickable ? clickLikeBtn : null}
+      userId={userId}
+      clickable={clickable}
+    >
       {likeId ? <HeartFillIcon /> : <HeartIcon />}
       <span>{totalLike}</span>
     </S.LikeBtn>

--- a/src/components/common/LikeBtn/style.tsx
+++ b/src/components/common/LikeBtn/style.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-export const LikeBtn = styled.div<{ userId: string }>`
+export const LikeBtn = styled.div<{ userId: string; clickable: boolean }>`
   display: inline-flex;
   align-items: center;
   svg {
@@ -14,6 +14,7 @@ export const LikeBtn = styled.div<{ userId: string }>`
   }
 
   &:hover svg {
-    transform: ${({ userId }) => (userId ? "scale(1.1)" : null)};
+    transform: ${({ userId, clickable }) =>
+      userId && clickable ? "scale(1.1)" : null};
   }
 `;

--- a/src/components/profile/index.tsx
+++ b/src/components/profile/index.tsx
@@ -4,9 +4,7 @@ import Modal from "./Modal";
 import Tab from "./Tab";
 import ProfileImageBox from "./ProfileImageBox";
 import EditFullName from "./EditFullName";
-
 import EditPassword from "./EditPassword";
-
 import FollowIcon from "./FollowIcon";
 
 export {

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useParams } from "react-router";
+import { useNavigate } from "react-router-dom";
 import Header from "@components/common/Header";
 import Footer from "@components/common/Footer";
 import Card from "@components/common/Card";
@@ -14,10 +15,55 @@ import {
 } from "@components/profile";
 import * as S from "./style";
 import { CardBox as SCardBox } from "../home/style";
+import { postAPI, userAPI } from "@utils/apis";
+import { IPost, IUser } from "src/types/model";
+import axios, { AxiosResponse } from "axios";
+
+const LIMIT = 6;
 
 const Profile: React.FC = () => {
-  const { id } = useParams<Record<string, string>>();
-  const user = DUMMY_USER;
+  const navigate = useNavigate();
+  const { id: profileUserId } = useParams<Record<string, string>>();
+
+  const [user, setUser] = useState<IUser>();
+  const [writtenPosts, setWrittenPosts] = useState<IPost[]>();
+  const [likedPosts, setLikedPosts] = useState<IPost[]>();
+
+  const getUser = async () => {
+    try {
+      const response = await userAPI.getUser(profileUserId);
+      setUser(response.data);
+    } catch (error) {
+      console.error(error);
+      navigate("/404");
+    }
+  };
+
+  const getPosts = async () => {
+    try {
+      const { data: posts } = await postAPI.allPost();
+      const _writtenPosts = [];
+      const _likedPosts = [];
+
+      posts.forEach((post) => {
+        const { author, likes } = post;
+        const isWrittenPost = author._id === profileUserId;
+        const isLikedPost = likes.some((like) => like.user === profileUserId);
+
+        if (isWrittenPost) _writtenPosts.push(post);
+        if (isLikedPost) _likedPosts.push(post);
+      });
+
+      setWrittenPosts(_writtenPosts);
+      setLikedPosts(_likedPosts);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    axios.all([getUser(), getPosts()]);
+  }, []);
 
   const [isMine, setIsMine] = useState(false);
   const [editFullNameVisible, setEditFullNameVisible] = useState(false);
@@ -26,112 +72,108 @@ const Profile: React.FC = () => {
   return (
     <>
       <Header />
-      <S.Wrapper padding="60px 0 0">
-        <CoverImageBox isMine={isMine} imgSrc={user.coverImage} />
-      </S.Wrapper>
 
-      <S.Layout>
-        <S.Wrapper margin="-32px 0 11px">
-          <ProfileImageBox
-            isMine={isMine}
-            imgSrc={user.image}
-            id={{
-              profile: "1",
-              visitor: "2"
-            }}
-            profileFullName={user.fullName}
-          />
-        </S.Wrapper>
+      {user === undefined ||
+      likedPosts === undefined ||
+      writtenPosts === undefined ? (
+        "로딩 중..."
+      ) : (
+        <>
+          <S.Wrapper padding="60px 0 0">
+            <CoverImageBox
+              isMine={profileUserId === user._id}
+              imgSrc={user.coverImage}
+            />
+          </S.Wrapper>
 
-        <button onClick={() => setIsMine(!isMine)}>
-          {isMine ? "다른 사람인 척" : "내 프로필인 척"}
-        </button>
+          <S.Layout>
+            <S.Wrapper margin="-32px 0 11px">
+              <ProfileImageBox
+                isMine={profileUserId === user._id}
+                imgSrc={user.image}
+                id={{
+                  profile: profileUserId,
+                  visitor: user._id
+                }}
+                profileFullName={user.fullName}
+              />
+            </S.Wrapper>
 
-        <S.FlexContainer direction="column" gap="6px">
-          <S.FullName>{user.fullName}</S.FullName>
-          <S.Email>{user.email}</S.Email>
-        </S.FlexContainer>
+            <S.FlexContainer direction="column" gap="6px">
+              <S.FullName>{user.fullName}</S.FullName>
+              <S.Email>{user.email}</S.Email>
+            </S.FlexContainer>
 
-        <S.DefinitionList>
-          <S.DefinitionItem>
-            <dt>팔로워</dt>
-            <dd>{user.followers.length}</dd>
-          </S.DefinitionItem>
+            <S.DefinitionList>
+              <S.DefinitionItem>
+                <dt>팔로워</dt>
+                <dd>{user.followers.length}</dd>
+              </S.DefinitionItem>
 
-          <S.DefinitionItem>
-            <dt>팔로워</dt>
-            <dd>{user.following.length}</dd>
-          </S.DefinitionItem>
+              <S.DefinitionItem>
+                <dt>팔로워</dt>
+                <dd>{user.following.length}</dd>
+              </S.DefinitionItem>
 
-          <S.DefinitionItem>
-            <dt>게시글</dt>
-            <dd>{user.posts.length}</dd>
-          </S.DefinitionItem>
-        </S.DefinitionList>
+              <S.DefinitionItem>
+                <dt>게시글</dt>
+                <dd>{user.posts.length}</dd>
+              </S.DefinitionItem>
+            </S.DefinitionList>
 
-        <Tab style={{ marginBottom: "30px" }}>
-          <Tab.Item active title="작성한 글 목록">
-            <SCardBox>
-              {Array.from({ length: 6 }).map((_, i) => (
-                <Card
-                  post={{
-                    ...DUMMY_POST,
-                    title: JSON.stringify(DUMMY_POST.title)
-                  }}
-                  key={i}
-                />
-              ))}
-            </SCardBox>
-          </Tab.Item>
-          <Tab.Item title="좋아요 한 글">
-            <SCardBox>
-              {Array.from({ length: 6 }).map((_, i) => (
-                <Card
-                  post={{
-                    ...DUMMY_POST,
-                    title: JSON.stringify(DUMMY_POST.title)
-                  }}
-                  key={i}
-                />
-              ))}
-            </SCardBox>
-          </Tab.Item>
-        </Tab>
+            <Tab style={{ marginBottom: "30px" }}>
+              <Tab.Item active title="작성한 글 목록">
+                <SCardBox>
+                  {writtenPosts.map((post, i) => {
+                    return <Card post={post} key={i} userId={user._id} />;
+                  })}
+                </SCardBox>
+              </Tab.Item>
+              <Tab.Item title="좋아요 한 글">
+                <SCardBox>
+                  {likedPosts.map((post, i) => (
+                    <Card post={post} key={i} userId={user._id} />
+                  ))}
+                </SCardBox>
+              </Tab.Item>
+            </Tab>
 
-        <S.Wrapper margin="52px 0 0">
-          <Button
-            buttonType="red"
-            width="300"
-            onClick={() => {
-              alert("onClick!");
-            }}
-          >
-            더보기
-          </Button>
-        </S.Wrapper>
+            <S.Wrapper margin="52px 0 0">
+              <Button
+                buttonType="red"
+                width="300"
+                onClick={() => {
+                  alert("onClick!");
+                }}
+              >
+                더보기
+              </Button>
+            </S.Wrapper>
 
-        <Modal
-          height="294px"
-          visible={editFullNameVisible}
-          onClose={() => setEditFullNameVisible(false)}
-        >
-          <EditFullName />
-        </Modal>
-        <button onClick={() => setEditFullNameVisible(true)}>
-          닉네임 변경 모달 얍
-        </button>
+            <Modal
+              height="294px"
+              visible={editFullNameVisible}
+              onClose={() => setEditFullNameVisible(false)}
+            >
+              <EditFullName />
+            </Modal>
+            <button onClick={() => setEditFullNameVisible(true)}>
+              닉네임 변경 모달 얍
+            </button>
 
-        <Modal
-          height="384px"
-          visible={editPasswordVisible}
-          onClose={() => setEditPasswordVisible(false)}
-        >
-          <EditPassword />
-        </Modal>
-        <button onClick={() => setEditPasswordVisible(true)}>
-          비밀번호 변경 모달 얍
-        </button>
-      </S.Layout>
+            <Modal
+              height="384px"
+              visible={editPasswordVisible}
+              onClose={() => setEditPasswordVisible(false)}
+            >
+              <EditPassword />
+            </Modal>
+            <button onClick={() => setEditPasswordVisible(true)}>
+              비밀번호 변경 모달 얍
+            </button>
+          </S.Layout>
+        </>
+      )}
 
       <Footer />
     </>
@@ -139,77 +181,3 @@ const Profile: React.FC = () => {
 };
 
 export default Profile;
-
-const DUMMY_USER = {
-  role: "Regular",
-  emailVerified: false,
-  banned: false,
-  isOnline: false,
-  posts: [],
-  likes: ["62a62a42c882bf3a287f9c99"],
-  comments: [],
-  followers: [],
-  following: [],
-  notifications: [],
-  messages: [],
-  _id: "62a0cf0bc882bf3a287f907c",
-  fullName: "유현naver",
-  email: "puh0128@naver.com",
-  createdAt: "2022-06-08T16:32:11.434Z",
-  updatedAt: "2022-06-12T18:29:22.721Z",
-  __v: 0,
-  username: "유현naver",
-  image:
-    "https://res.cloudinary.com/learnprogrammers/image/upload/v1655428928/user/7128b331-10d5-4771-b33f-afa6448b64bd.png",
-  imagePublicId: "user/6ecb4177-78ea-4362-96a4-e95903a6e84a",
-  coverImage:
-    "https://res.cloudinary.com/learnprogrammers/image/upload/v1655058503/user/99bff83a-15db-4b49-bedc-7ae907aebbbe.jpg",
-  coverImagePublicId: "user/99bff83a-15db-4b49-bedc-7ae907aebbbe"
-};
-
-const DUMMY_POST = {
-  likes: [],
-  comments: [],
-  _id: "62a8cfb53229d934e9b64d3d",
-  title: {
-    title: "✨샘플",
-    introduction: "test중 입니다.",
-    email: "knk@gmail.com",
-    expectedDate: "1개월",
-    place: "online",
-    startDate: "2022/06/06",
-    parts: { channel: "front", people: "5", skills: [["html5"], ["nextJs"]] }
-  },
-  channel: {
-    authRequired: false,
-    posts: ["62a8cfb53229d934e9b64d3d", "62a958533229d934e9b6506e"],
-    _id: "62a55eb0c882bf3a287f9623",
-    name: "ios",
-    description: "ios",
-    createdAt: "2022-06-12T03:34:08.725Z",
-    updatedAt: "2022-06-15T05:07:50.553Z",
-    __v: 0
-  },
-  author: {
-    role: "Regular",
-    emailVerified: false,
-    banned: false,
-    isOnline: false,
-    posts: [],
-    likes: [],
-    comments: [],
-    followers: [],
-    following: [],
-    notifications: [],
-    messages: [],
-    _id: "62a6d6c977ad437a6b8f3614",
-    fullName: "knk",
-    email: "knk@gmail.com",
-    createdAt: "2022-06-13T06:18:49.164Z",
-    updatedAt: "2022-06-13T06:34:06.411Z",
-    __v: 0
-  },
-  createdAt: "2022-06-14T18:13:09.711Z",
-  updatedAt: "2022-06-14T18:18:27.673Z",
-  __v: 0
-};


### PR DESCRIPTION
# 개요
프로필 페이지에 현재 사이트를 보고 있는 사용자와 프로필 페이지의 사용자에 대한 정보에 서버 API와 context를 연결했습니다. 
# 작업 내용
- 프로필 페이지에서는 카드 좋아요가 되지 않도록 방어
- 서버 API통신과 context로 프로필 페이지의 유저 정보와 해당 페이지를 보고 있는 유저의 정보 가져와서 뿌려주기
- 서버 API 통신으로 작성한 글, 좋아요 한 글 데이터 가져와서 뿌려주기
- 자신의 프로필 페이지 / 다른 사람의 프로필 페이지에 대한 분기 처리
# 관련 이슈
- `좋아요 한 글 목록`은 카드 컴포넌트에 전달할 post 데이터를 가져오기 위해 좋아요 한 글의 갯수만큼 서버 API를 찔러야 함
  - 전체 포스트를 가져오는 API를 한 번 찌르고, 필터링하여 작성한 글 목록, 좋아요 한 글 목록 데이터를 가져오도록 함
- 카드의 좋아요 버튼
  - 프로필 페이지가 **마운트 될 때에만** 포스트 정보를 가져오기 때문에 `작성한 글 목록`, `좋아요 한 글 목록` 내 카드의 좋아요 버튼을 눌러도 좋아요 기능이 제대로 동작은 하지만 데이터 동기화가 되지 않음
  - 예시)
    -  작성한 글 목록에서 A라는 카드 컴포넌트의 좋아요 버튼을 클릭 -> 좋아요 한 글 목록으로 Tab 컨텐츠 스위칭 -> 좋아요 한 글 목록에는 A 카드 컴포넌트가 없음, 다시 작성한 글 목록으로 스위칭해도 A 카드 컴포넌트 정보는 좋아요를 하기 전 상태
  - 우선 프로필 페이지에서는 카드 컴포넌트의 좋아요 버튼을 클릭할 수 없게 만듦 (Card, LikeBtn 컴포넌트에 props.clickable 을 추가)
  **- 이대로 가도 될지, 다른 방법이 있는지 논의해야 할 것 같습니다!**
- 사용자가 누구냐에 따라 팔로우, 팔로워 컴포넌트 분기 처리 해야 함
  - 시간이 된다면, @Hyevvy 님의 디자인으로 변경할 수도 있음
    
    ![image](https://user-images.githubusercontent.com/96400112/174686864-09bb58a1-1e01-46bd-84e4-d6d9db9819c8.png)

- 더보기 기능 추가해야 함
- 드랍다운 추가해야 함
  
  ![image](https://user-images.githubusercontent.com/96400112/174686307-fd1885b6-a869-4c9c-8a94-83b5d925e2ea.png)



# 사진
**자신의 프로필 페이지**
![profile api](https://user-images.githubusercontent.com/96400112/174686630-32859472-88f4-4b9b-92a7-7e8fe1cb4741.gif)

**남의 프로필 페이지**
![nam profile api](https://user-images.githubusercontent.com/96400112/174686754-5151029e-f738-42df-aa71-e35c5dfe6b43.gif)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #229 