### PR TITLE
:bug: fix: PartBox Select AI 선택시 Options 못 찾는 오류 수정

### DIFF
--- a/src/components/create/PartBox/PartBox.jsx
+++ b/src/components/create/PartBox/PartBox.jsx
@@ -53,13 +53,16 @@ const PartBox = ({
   }, [channel, people, skills]);
 
   const getSkillOptions = (channel) => {
+    console.log(channel);
     let idx = SKILL_OPTIONS.findIndex(
-      (skillOption) => skillOption.channel === channel
+      (skillOption) =>
+        skillOption.channel.toLowerCase() === channel.toLowerCase()
     );
     setStackOptions(SKILL_OPTIONS[idx].options);
   };
 
   React.useEffect(() => {
+    console.log(channel);
     if (!disabled) setSkills([]);
     getSkillOptions(channel);
   }, [channel]);


### PR DESCRIPTION
# 개요
PartBox Select AI 선택시 Options 못 찾는 오류 수정
기존에 대소문자로 인해서 오류가 발생했습니다..!! 

# 사진
https://user-images.githubusercontent.com/72402747/174840799-fe752260-db04-4eef-a4f4-56b80c6a3740.mov

이제 잘 되네용 

close #286
