### PR TITLE
🐛 fix: 글 생성, 수정 이후 메인페이지 navigate 안 되던 버그 수정

### DIFF
--- a/src/pages/create/create.tsx
+++ b/src/pages/create/create.tsx
@@ -87,7 +87,7 @@ const Create: React.FC = () => {
       formData.append("channelId", currentChannelId);
       const getPost = async (formData: FormData) => {
         await postAPI.createPost(formData).then((res) => {
-          if (res.statusText === "OK") {
+          if (res.status === 200) {
             navigate("/");
           }
         });

--- a/src/pages/edit/edit.tsx
+++ b/src/pages/edit/edit.tsx
@@ -95,11 +95,8 @@ const Edit: React.FC = () => {
 
     const editPost = async (formData: FormData) => {
       await postAPI.updatePost(formData).then((res) => {
-        if (res.statusText === "OK") {
-          const ret = confirm(
-            "수정이 완료되었습니다. 메인페이지로 이동합니다."
-          );
-          if (ret) navigate("/");
+        if (res.status === 200) {
+          navigate("/");
         }
       });
     };


### PR DESCRIPTION
# 개요
[잘만 되던 수정, 생성시 메인페이지 navigate 기능](https://github.com/prgrms-fe-devcourse/FEDC2_2JAVATAYO_Dongyoung/pull/221) 이 갑자기 안 되었음
-> 왜지.. ?? 
-> 알고보니 **서버 응답값이 갑자기 바뀜 ㅠ ㅠ** 

# 작업 내용
이전에는 statusText 가 Ok였는뎅,, 

바뀐 서버 응답값을 보니 statusText 비어있음 ㅠ
<img width="356" alt="스크린샷 2022-06-22 오전 12 52 55" src="https://user-images.githubusercontent.com/72402747/174843673-4bd9fafc-cb5d-4605-ad0b-d0d0ab236937.png">


그래서 그냥 `status === 200` 으로 제 자신과 원만한 합의봤네요

 
# 사진

⭐️ 생성시 잘 되는 증거영상

https://user-images.githubusercontent.com/72402747/174844140-a0219f09-e3a4-4840-a82e-3caaf0ea443e.mov

⭐️ 수정시 잘 되는 증거영상 

https://user-images.githubusercontent.com/72402747/174844152-ec53b7a6-6c50-4a9f-ae41-d7c6c45d6148.mov





<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
close #294 