### PR TITLE
✨ feat: SettingDropDown 컴포넌트 구현

### DIFF
--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,6 +1,7 @@
 import AppLayout from "./AppLayout";
 import Button from "./Button";
 import Card from "./Card";
+import DropDown from "./DropDown";
 import ErrorMessage from "./ErrorMessage";
 import Footer from "./Footer";
 import Header from "./Header";
@@ -17,6 +18,7 @@ export {
   AppLayout,
   Button,
   Card,
+  DropDown,
   Footer,
   ErrorMessage,
   ProfileImage,

--- a/src/components/profile/CoverImageBox/CoverImageBox.tsx
+++ b/src/components/profile/CoverImageBox/CoverImageBox.tsx
@@ -8,28 +8,19 @@ import * as S from "./style";
 interface CoverImageBoxInterface {
   isMine: boolean;
   imgSrc: string;
+  handleImageUpload: (file: File) => void;
 }
 
-const CoverImageBox: FC<CoverImageBoxInterface> = ({ isMine, imgSrc }) => {
-  const [src, setSrc] = useState(imgSrc);
+const CoverImageBox: FC<CoverImageBoxInterface> = ({
+  isMine,
+  imgSrc,
+  handleImageUpload
+}) => {
   const [ref, hover] = useHover<HTMLDivElement>();
-
-  const handleImageUpload = async (file: File) => {
-    const formData = new FormData();
-    formData.append("image", file);
-
-    try {
-      const response = await userAPI.changeCoverImage(formData);
-
-      setSrc(response.data.coverImage);
-    } catch (error) {
-      console.error(error);
-    }
-  };
 
   return (
     <S.CoverImageWrapper ref={ref}>
-      <CoverImage imgSrc={src} />
+      <CoverImage imgSrc={imgSrc} />
       {isMine && hover ? (
         <ImageUpload
           onImageUpload={handleImageUpload}

--- a/src/components/profile/ProfileImageBox/ProfileImageBox.tsx
+++ b/src/components/profile/ProfileImageBox/ProfileImageBox.tsx
@@ -1,31 +1,18 @@
 import { FC, useState } from "react";
-import { ProfileImage, ImageUpload } from "@components/common";
-import { FollowIcon } from "@components/profile";
-import { ReactComponent as SettingComponent } from "@assets/icons/icon_setting.svg";
+import { ProfileImage } from "@components/common";
+import SettingDropDown from "../SettingDropDown";
 import { userAPI } from "@utils/apis";
 import * as S from "./style";
 
 interface ProfileImageBoxInterface {
   isMine: boolean;
   imgSrc: string;
-  id: Id;
-  profileFullName: string;
 }
 
-export type Id = {
-  profile: string;
-  visitor: string;
-};
-
-const ProfileImageBox: FC<ProfileImageBoxInterface> = ({
-  isMine,
-  imgSrc,
-  id,
-  profileFullName
-}) => {
+const ProfileImageBox: FC<ProfileImageBoxInterface> = ({ isMine, imgSrc }) => {
   const [src, setSrc] = useState(imgSrc);
 
-  const handleImageUpload = async (file) => {
+  const handleImageUpload = async (file: File) => {
     const formData = new FormData();
     formData.append("image", file);
 
@@ -42,15 +29,7 @@ const ProfileImageBox: FC<ProfileImageBoxInterface> = ({
     <S.ProfileImageWrapper>
       <ProfileImage imgSrc={src} size="lg" />
       {isMine ? (
-        <ImageUpload
-          onImageUpload={handleImageUpload}
-          replacement={<SettingComponent width="20px" height="20px" />}
-          replacementStyle={{
-            position: "absolute",
-            bottom: "0",
-            right: "-3px"
-          }}
-        />
+        <SettingDropDown handleImageUpload={handleImageUpload} />
       ) : null}
     </S.ProfileImageWrapper>
   );

--- a/src/components/profile/ProfileImageBox/ProfileImageBox.tsx
+++ b/src/components/profile/ProfileImageBox/ProfileImageBox.tsx
@@ -8,30 +8,34 @@ import * as S from "./style";
 interface ProfileImageBoxInterface {
   isMine: boolean;
   imgSrc: string;
-  updatePosts: () => Promise<void>;
+  handleImageUpload: (file: File) => void;
 }
 
-const ProfileImageBox: FC<ProfileImageBoxInterface> = ({ isMine, imgSrc }) => {
-  const [src, setSrc] = useState<string>(imgSrc);
-  const { onUpdate } = useAuth();
+const ProfileImageBox: FC<ProfileImageBoxInterface> = ({
+  isMine,
+  imgSrc,
+  handleImageUpload
+}) => {
+  // const [src, setSrc] = useState<string>(imgSrc);
+  // const { onUpdate } = useAuth();
 
-  const handleImageUpload = async (file: File) => {
-    const formData = new FormData();
-    formData.append("image", file);
+  // const handleImageUpload = async (file: File) => {
+  //   const formData = new FormData();
+  //   formData.append("image", file);
 
-    try {
-      const { data } = await userAPI.changeProfileImage(formData);
+  //   try {
+  //     const { data } = await userAPI.changeProfileImage(formData);
 
-      onUpdate(data);
-      setSrc(data.image);
-    } catch (error) {
-      console.error(error);
-    }
-  };
+  //     onUpdate(data);
+  //     setSrc(data.image);
+  //   } catch (error) {
+  //     console.error(error);
+  //   }
+  // };
 
   return (
     <S.ProfileImageWrapper>
-      <ProfileImage imgSrc={src} size="lg" />
+      <ProfileImage imgSrc={imgSrc} size="lg" />
       {isMine ? (
         <SettingDropDown handleImageUpload={handleImageUpload} />
       ) : null}

--- a/src/components/profile/ProfileImageBox/ProfileImageBox.tsx
+++ b/src/components/profile/ProfileImageBox/ProfileImageBox.tsx
@@ -2,24 +2,28 @@ import { FC, useState } from "react";
 import { ProfileImage } from "@components/common";
 import SettingDropDown from "../SettingDropDown";
 import { userAPI } from "@utils/apis";
+import { useAuth } from "@contexts/AuthProvider";
 import * as S from "./style";
 
 interface ProfileImageBoxInterface {
   isMine: boolean;
   imgSrc: string;
+  updatePosts: () => Promise<void>;
 }
 
 const ProfileImageBox: FC<ProfileImageBoxInterface> = ({ isMine, imgSrc }) => {
-  const [src, setSrc] = useState(imgSrc);
+  const [src, setSrc] = useState<string>(imgSrc);
+  const { onUpdate } = useAuth();
 
   const handleImageUpload = async (file: File) => {
     const formData = new FormData();
     formData.append("image", file);
 
     try {
-      const response = await userAPI.changeProfileImage(formData);
+      const { data } = await userAPI.changeProfileImage(formData);
 
-      setSrc(response.data.image);
+      onUpdate(data);
+      setSrc(data.image);
     } catch (error) {
       console.error(error);
     }

--- a/src/components/profile/SettingDropDown/SettingDropDown.tsx
+++ b/src/components/profile/SettingDropDown/SettingDropDown.tsx
@@ -1,0 +1,67 @@
+import { FC, useState, useRef } from "react";
+import { ImageUpload, DropDown } from "@components/common";
+import { EditFullName, EditPassword, Modal } from "@components/profile";
+import { ReactComponent as SettingComponent } from "@assets/icons/icon_setting.svg";
+import * as S from "./style";
+import theme from "../../../styles/theme";
+
+interface SettingDropDownInterface {
+  handleImageUpload: (file: File) => void;
+}
+
+const SettingDropDown: FC<SettingDropDownInterface> = ({
+  handleImageUpload
+}) => {
+  const [editFullNameVisible, setEditFullNameVisible] = useState(false);
+  const [editPasswordVisible, setEditPasswordVisible] = useState(false);
+
+  const refImageUpload = useRef(null);
+
+  const dropDownContents = [
+    {
+      label: <S.DropBox>프로필 이미지 변경</S.DropBox>,
+      event: () => {
+        refImageUpload.current.click();
+      }
+    },
+    {
+      label: <S.DropBox>닉네임 변경</S.DropBox>,
+      event: () => setEditFullNameVisible(true)
+    },
+    {
+      label: <S.DropBox>비밀번호 변경</S.DropBox>,
+      event: () => setEditPasswordVisible(true)
+    }
+  ];
+
+  return (
+    <DropDown contents={dropDownContents} top={10} left={-32}>
+      <S.Wrapper>
+        <SettingComponent width="20px" height="20px" color={theme.$gray800} />
+      </S.Wrapper>
+
+      <ImageUpload
+        onImageUpload={handleImageUpload}
+        replacement={<div ref={refImageUpload}></div>}
+      />
+
+      <Modal
+        height="294px"
+        visible={editFullNameVisible}
+        onClose={() => setEditFullNameVisible(false)}
+      >
+        <EditFullName />
+      </Modal>
+
+      <Modal
+        height="384px"
+        visible={editPasswordVisible}
+        onClose={() => setEditPasswordVisible(false)}
+      >
+        <EditPassword />
+      </Modal>
+    </DropDown>
+  );
+};
+
+export default SettingDropDown;

--- a/src/components/profile/SettingDropDown/index.ts
+++ b/src/components/profile/SettingDropDown/index.ts
@@ -1,0 +1,3 @@
+import SettingDropDown from "./SettingDropDown";
+
+export default SettingDropDown;

--- a/src/components/profile/SettingDropDown/style.ts
+++ b/src/components/profile/SettingDropDown/style.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.span`
+  position: absolute;
+  bottom: 0;
+  right: -3px;
+`;
+
+export const DropBox = styled.div`
+  width: 112px;
+  font-size: 12px;
+  padding: 0;
+`;

--- a/src/components/profile/index.ts
+++ b/src/components/profile/index.ts
@@ -5,6 +5,7 @@ import EditPassword from "./EditPassword";
 import FollowIcon from "./FollowIcon";
 import Modal from "./Modal";
 import ProfileImageBox from "./ProfileImageBox";
+import SettingDropDown from "./SettingDropDown";
 import Tab from "./Tab";
 
 export {
@@ -15,5 +16,6 @@ export {
   FollowIcon,
   Modal,
   ProfileImageBox,
+  SettingDropDown,
   Tab
 };

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -9,9 +9,6 @@ import {
   Tab,
   ProfileImageBox,
   CoverImageBox,
-  EditFullName,
-  EditPassword,
-  Modal,
   FollowIcon
 } from "@components/profile";
 import * as S from "./style";
@@ -71,7 +68,6 @@ const Profile: React.FC = () => {
     try {
       const response = await authAPI.checkAuthUser();
       onUpdate({ ...response.data });
-      console.log(userInfo);
     } catch (error) {
       console.error(error);
     }
@@ -121,8 +117,11 @@ const Profile: React.FC = () => {
     axios.all([getProfileUser(), getPosts()]);
   }, []);
 
-  const [editFullNameVisible, setEditFullNameVisible] = useState(false);
-  const [editPasswordVisible, setEditPasswordVisible] = useState(false);
+  useEffect(() => {
+    setWritten(INITIAL_POSTS);
+    setLiked(INITIAL_POSTS);
+    getPosts();
+  }, [userInfo]);
 
   return (
     <>
@@ -140,7 +139,11 @@ const Profile: React.FC = () => {
 
           <S.Layout>
             <S.Wrapper margin="-32px 0 11px">
-              <ProfileImageBox isMine={isMine} imgSrc={profileUser.image} />
+              <ProfileImageBox
+                isMine={isMine}
+                imgSrc={profileUser.image}
+                updatePosts={getPosts}
+              />
             </S.Wrapper>
 
             <S.FlexContainer direction="column" gap="6px">

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -37,10 +37,10 @@ const Profile: React.FC = () => {
 
   const { userInfo, onUpdate } = useAuth();
 
+  const isMine = userInfo.isLoggedIn ? profileUserId === userInfo._id : false;
   const [profileUser, setProfileUser] = useState<IUser>();
   const [written, setWritten] = useState<Posts>(INITIAL_POSTS);
   const [liked, setLiked] = useState<Posts>(INITIAL_POSTS);
-  const isMine = userInfo.isLoggedIn ? profileUserId === userInfo._id : false;
 
   const handleCreateFollow = (followData) => {
     setProfileUser({
@@ -100,18 +100,17 @@ const Profile: React.FC = () => {
     }
   }, []);
 
-  const getProfileUser = useCallback(async () => {
+  const getProfileUser = async () => {
     try {
-      console.log("getProfileUser");
       const response = await userAPI.getUser(profileUserId);
       setProfileUser(response.data);
     } catch (error) {
       console.error(error);
       navigate("/404");
     }
-  }, []);
+  };
 
-  const getPosts = useCallback(async () => {
+  const getPosts = async () => {
     try {
       const { data: posts } = await postAPI.allPost();
       const _writtenPosts: IPost[] = [];
@@ -139,10 +138,13 @@ const Profile: React.FC = () => {
     } catch (error) {
       console.error(error);
     }
-  }, []);
+  };
 
   useEffect(() => {
-    axios.all([getProfileUser(), getPosts()]);
+    setWritten(INITIAL_POSTS);
+    setLiked(INITIAL_POSTS);
+    getProfileUser();
+    getPosts();
   }, [profileUserId]);
 
   useEffect(() => {
@@ -179,8 +181,10 @@ const Profile: React.FC = () => {
             </S.Wrapper>
 
             <S.FlexContainer direction="column" gap="6px">
-              <S.FullName>{profileUser.fullName}</S.FullName>
-              <S.Email>{profileUser.email}</S.Email>
+              <S.FullName>
+                {isMine ? userInfo.fullName : profileUser.fullName}
+              </S.FullName>
+              <S.Email>{isMine ? userInfo.email : profileUser.email}</S.Email>
             </S.FlexContainer>
 
             {!isMine && userInfo.isLoggedIn ? (
@@ -261,12 +265,12 @@ const Profile: React.FC = () => {
                 </SCardBox>
 
                 <S.Wrapper margin="52px 0 0" center>
-                  {getEndIndex(written.countClickMore) < written.total ? (
+                  {getEndIndex(liked.countClickMore) < liked.total ? (
                     <Button
                       buttonType="red"
                       width="300"
                       onClick={() =>
-                        setWritten({
+                        setLiked({
                           ...liked,
                           countClickMore: liked.countClickMore + 1
                         })

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -17,7 +17,7 @@ import {
 import * as S from "./style";
 import { CardBox as SCardBox } from "../home/style";
 import { authAPI, postAPI, userAPI } from "@utils/apis";
-import { IPost, IUser, IFollow } from "../../types/model";
+import { IPost, IUser } from "../../types/model";
 import axios from "axios";
 import { useAuth } from "@contexts/AuthProvider";
 
@@ -140,15 +140,7 @@ const Profile: React.FC = () => {
 
           <S.Layout>
             <S.Wrapper margin="-32px 0 11px">
-              <ProfileImageBox
-                isMine={isMine}
-                imgSrc={profileUser.image}
-                id={{
-                  profile: profileUserId,
-                  visitor: userInfo.isLoggedIn ? "" : userInfo._id
-                }}
-                profileFullName={profileUser.fullName}
-              />
+              <ProfileImageBox isMine={isMine} imgSrc={profileUser.image} />
             </S.Wrapper>
 
             <S.FlexContainer direction="column" gap="6px">
@@ -251,28 +243,6 @@ const Profile: React.FC = () => {
                 </S.Wrapper>
               </Tab.Item>
             </Tab>
-
-            <Modal
-              height="294px"
-              visible={editFullNameVisible}
-              onClose={() => setEditFullNameVisible(false)}
-            >
-              <EditFullName />
-            </Modal>
-            <button onClick={() => setEditFullNameVisible(true)}>
-              닉네임 변경 모달 얍
-            </button>
-
-            <Modal
-              height="384px"
-              visible={editPasswordVisible}
-              onClose={() => setEditPasswordVisible(false)}
-            >
-              <EditPassword />
-            </Modal>
-            <button onClick={() => setEditPasswordVisible(true)}>
-              비밀번호 변경 모달 얍
-            </button>
           </S.Layout>
         </>
       )}


### PR DESCRIPTION
# 개요
SettingDropDown 컴포넌트 구현
# 작업 내용
- 프로필 이미지 밑에 있는 톱니바퀴 아이콘 클릭 시 나오는 컴포넌트
- #269 @Hyevvy 리포트 해주신 2개의 버그 fix (SettingDropDown 컴포넌트를 구현하다..만난 버그를 해결하다..혜경님이 말한 버그까지 해결했습니다. 꼬리에 꼬리를 물어 브랜치가 여러 기능을 담당해버린 점 죄송합니다😭)
# 관련 이슈
- 프로필 이미지 변경
  - 작성한 글, 좋아요 한 글 목록에 프로필 유저가 작성자인 카드의 이미지 또한 변경되어야 해서 전체 포스트를 가져오는 API를 다시 찔러야 함 → 깜빡임... 로딩 처리해야 함
 
- DropDown 디자인
  - DropDown 컴포넌트를 사용할 때 props.contents 값으로 React.ReactNode를 넘기면 알림에서 사용하는 디자인이 적용됨
    
<img src="https://user-images.githubusercontent.com/96400112/174888573-de70bbf7-bbac-428d-8cf3-cb669fb4217b.png" />


# 사진

![셋팅드랍다운](https://user-images.githubusercontent.com/96400112/174887756-fb93abf4-82be-4eac-8036-ad8e3db171ea.gif)

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #249 