### PR TITLE
🐛 bug: 로그인 상태에서 로그인, 회원가입 페이지 접근 시 메인으로 돌리기

### DIFF
--- a/src/pages/signIn/signIn.tsx
+++ b/src/pages/signIn/signIn.tsx
@@ -15,7 +15,10 @@ type Values = {
 };
 const SignIn: FC = () => {
   const navigate = useNavigate();
-  const { onLogin } = useAuth();
+  const { userInfo, onLogin } = useAuth();
+  if (userInfo.isLoggedIn) {
+    navigate("/");
+  }
   const { values, errors, isLoading, handleChange, handleSubmit } =
     useForm<Values>({
       initialValue: {

--- a/src/pages/signUp/signUp.tsx
+++ b/src/pages/signUp/signUp.tsx
@@ -18,7 +18,10 @@ type Values = {
 };
 const SignUp: FC = () => {
   const navigate = useNavigate();
-  const { onLogin } = useAuth();
+  const { userInfo, onLogin } = useAuth();
+  if (userInfo.isLoggedIn) {
+    navigate("/");
+  }
   const [isChecked, setIsChecked] = useState(false);
   const { values, errors, isLoading, handleChange, handleSubmit } =
     useForm<Values>({
@@ -81,6 +84,7 @@ const SignUp: FC = () => {
       setIsChecked(true);
     }
   };
+
   return (
     <Fragment>
       <AppLayout>


### PR DESCRIPTION
# 개요
🐛 bug: 로그인 상태에서 로그인, 회원가입 페이지 접근 시 메인으로 돌리기
# 작업 내용
**이전**
로그인 상태
-> 로그인 페이지: 404 페이지
-> 회원가입 페이지: 접속 가능 (단 url에 유저가 직접 치고 들어가야 함)

**변경 후**
로그인 상태 시 메인으로 바로 이동

# 관련 이슈
close #300 
# 사진

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
