### PR TITLE
🐛 fix: 상세페이지 게시글 좋아요 영역에 비회원은 cursor: default 처리

### DIFF
--- a/src/components/detail/PostHeader/PostHeader.tsx
+++ b/src/components/detail/PostHeader/PostHeader.tsx
@@ -59,7 +59,9 @@ const PostHeader: React.FC<PostHeaderInterface> = ({
         <span onClick={backButtonClick} style={{ cursor: "pointer" }}>
           <BackIcon />
         </span>
-        <S.CenterAlignItemSpan style={{ cursor: "pointer" }}>
+        <S.CenterAlignItemSpan
+          style={userId != null ? { cursor: "pointer" } : { cursor: "default" }}
+        >
           <LikeBtn likes={likes} userId={userId} postId={postId} />
         </S.CenterAlignItemSpan>
       </S.FlexBetween>


### PR DESCRIPTION
# 개요
기존에는 비회원도 좋아요 영역에 마우스를 올리면  cursor: pointer 처리가 되었음

# 작업 내용
상세페이지 게시글 좋아요 영역에 비회원은 cursor: default 처리

closes #333 