### PR TITLE
🐛 fix: 사용자 검색 조건 필터를 equal에서 like로 변경, 엔터로 검색 추가, BottomSheet 페이지 별로 show/hide 처리

### DIFF
--- a/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.tsx
@@ -1,6 +1,6 @@
 import * as S from "./style";
 import React, { useRef, useEffect, useState } from "react";
-import { userAPI } from "@utils/apis";
+import { userAPI, searchAPI } from "@utils/apis";
 import { ReactComponent as SearchIcon } from "@assets/icons/icon_search.svg";
 import User from "../User";
 
@@ -13,6 +13,11 @@ const BottomSheet = () => {
   useEffect(() => {
     getUserList();
   }, []);
+  const inputOnEnterPress = (e) => {
+    if (e.key === "Enter") {
+      search();
+    }
+  };
   const search = async () => {
     if (input.current.value.length !== 0) {
       getUser();
@@ -44,13 +49,12 @@ const BottomSheet = () => {
   };
   const getUser = async () => {
     try {
-      const filteredUser = saveUserList.filter(
-        (user) => user.fullName === input.current.value.replaceAll(" ", "")
+      const { data } = await searchAPI.searchUsers(
+        input.current.value.replaceAll(" ", "")
       );
-      if (filteredUser.length > 0) {
-        const { data } = await userAPI.getUser(filteredUser[0]._id);
+      if (data.length > 0) {
         setIsFindUser(true);
-        setUserList([data]);
+        setUserList(data);
       } else {
         setIsFindUser(false);
         setUserList([]);
@@ -113,7 +117,11 @@ const BottomSheet = () => {
           <S.BottomSheetContents>
             <S.Content>
               <S.InputBox>
-                <S.Input ref={input} placeholder="검색어를 입력해 주세요" />
+                <S.Input
+                  ref={input}
+                  onKeyUp={inputOnEnterPress}
+                  placeholder="검색어를 입력해 주세요"
+                />
                 <S.SearchBtn onClick={() => search()}>
                   <SearchIcon />
                 </S.SearchBtn>

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -2,7 +2,8 @@ import githubIcon from "@assets/icons/icon_github.svg";
 import youtubeIcon from "@assets/icons/icon_youtube.svg";
 import bannerImg from "@assets/imgs/search_banner.jpg";
 import { useAuth } from "@contexts/AuthProvider";
-import { useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation } from "react-router";
 import BottomSheet from "../BottomSheet";
 import * as S from "./style";
 
@@ -14,7 +15,17 @@ type footerInterface = { banner?: boolean };
 const Footer: React.FC<footerInterface> = ({ banner }) => {
   const navigate = useNavigate();
   const { userInfo } = useAuth();
-
+  const location = useLocation();
+  const [isBottomSheetHide, setIsBottomSheetHide] = useState(false);
+  useEffect(() => {
+    const pathNameSplit = location.pathname.split("/");
+    const hideBottomSheetPage = ["signin", "signUp", "create", "edit"];
+    setIsBottomSheetHide(
+      hideBottomSheetPage.some((pageName) =>
+        pathNameSplit[1].includes(pageName)
+      )
+    );
+  }, [location]);
   const bannerClick = () => {
     if (userInfo.isLoggedIn) {
       navigate("/create");
@@ -55,7 +66,7 @@ const Footer: React.FC<footerInterface> = ({ banner }) => {
               </a>
             </S.SocialLink>
           </div>
-          <BottomSheet />
+          {isBottomSheetHide ? null : <BottomSheet />}
         </S.Wrap>
       </S.Footer>
     </div>


### PR DESCRIPTION
# 개요
- 사용자 검색 조건 필터가 equal로 되어있어 검색에 불편함이 있음
- Enter KeyUp 이벤트가 없어 검색에 불편함이 있음

# 작업 내용
Search API 사용하니까 4시간 걸려서 지지고 볶고 구현하던 부분이 10분으로 단축되었네요... 🥲
- 사용자 검색 조건 필터를 equal에서 like로 변경
- Enter KeyUp으로 검색 추가
- BottomSheet 페이지 별로 show/hide 처리

# 관련 이슈
closes #338 

