### PR TITLE
🐛 fix: 업적 기준이 0으로 설정된 문제

### DIFF
--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -23,7 +23,7 @@ const INITIAL_POSTS = {
   total: 0
 };
 
-const REWARD_STANDARD = 0;
+const REWARD_STANDARD = 5;
 
 type Posts = {
   posts: IPost[];


### PR DESCRIPTION
# 개요

# 작업 내용
테스트하다가 업적 기준이 0인 커밋으로 올렸네요!!! 5개로 변경!!!!
# 관련 이슈

# 사진

<!-- closes #이슈번호 작성해야 칸반보드에서 이슈와 PR이 함께 Done으로 넘어갑니다-->
closes #342